### PR TITLE
Update interface for shader creation, fix tracelogging assumptions

### DIFF
--- a/include/RootSignature.hpp
+++ b/include/RootSignature.hpp
@@ -80,7 +80,7 @@ namespace D3D12TranslationLayer
                 m_SRVBucket = c_SRVBuckets - 1;
                 m_UsesShaderInterfaces = 0;
             }
-            ShaderStage(Shader* pShader) : ShaderStage()
+            ShaderStage(SShaderDecls const* pShader) : ShaderStage()
             {
                 if (pShader)
                 {
@@ -111,12 +111,12 @@ namespace D3D12TranslationLayer
         UINT m_NumSRVSpacesUsed[5];
 
         template <int N>
-        static Flags ComputeFlags(bool bRequiresBufferOutOfBoundsHandling, std::array<Shader*, N> const& shaders)
+        static Flags ComputeFlags(bool bRequiresBufferOutOfBoundsHandling, std::array<SShaderDecls const*, N> const& shaders)
         {
             UINT flags =
                 ((N == 1) ? Compute : 0) |
                 (bRequiresBufferOutOfBoundsHandling ? RequiresBufferOutOfBoundsHandling : 0);
-            for (Shader* pShader : shaders)
+            for (SShaderDecls const* pShader : shaders)
             {
                 if (pShader && pShader->m_bUsesInterfaces)
                 {
@@ -127,7 +127,7 @@ namespace D3D12TranslationLayer
             return (Flags)flags;
         }
 
-        RootSignatureDesc(Shader* pVS, Shader* pPS, Shader* pGS, Shader* pHS, Shader* pDS, bool bRequiresBufferOutOfBoundsHandling)
+        RootSignatureDesc(SShaderDecls const* pVS, SShaderDecls const* pPS, SShaderDecls const* pGS, SShaderDecls const* pHS, SShaderDecls const* pDS, bool bRequiresBufferOutOfBoundsHandling)
             : m_ShaderStages{
                 { ShaderStage(pPS) },
                 { ShaderStage(pVS) },
@@ -135,7 +135,7 @@ namespace D3D12TranslationLayer
                 { ShaderStage(pHS) },
                 { ShaderStage(pDS) } }
             , m_UAVBucket(NonCBBindingCountToBucket(NumUAVBindings(pVS, pPS, pGS, pHS, pDS)))
-            , m_Flags(ComputeFlags(bRequiresBufferOutOfBoundsHandling, std::array<Shader*, 5>{ pPS, pVS, pGS, pHS, pDS }))
+            , m_Flags(ComputeFlags(bRequiresBufferOutOfBoundsHandling, std::array<SShaderDecls const*, 5>{ pPS, pVS, pGS, pHS, pDS }))
             , m_NumSRVSpacesUsed{
                 pPS ? pPS->m_NumSRVSpacesUsed : 1u,
                 pVS ? pVS->m_NumSRVSpacesUsed : 1u,
@@ -144,11 +144,11 @@ namespace D3D12TranslationLayer
                 pDS ? pDS->m_NumSRVSpacesUsed : 1u }
         {
         }
-        RootSignatureDesc(Shader* pCS, bool bRequiresBufferOutOfBoundsHandling)
+        RootSignatureDesc(SShaderDecls const* pCS, bool bRequiresBufferOutOfBoundsHandling)
             : m_ShaderStages{
                 { ShaderStage(pCS) } }
                 , m_UAVBucket(NonCBBindingCountToBucket(pCS ? (UINT)pCS->m_UAVDecls.size() : 0u))
-            , m_Flags(ComputeFlags(bRequiresBufferOutOfBoundsHandling, std::array<Shader*, 1>{ pCS }))
+            , m_Flags(ComputeFlags(bRequiresBufferOutOfBoundsHandling, std::array<SShaderDecls const*, 1>{ pCS }))
             , m_NumSRVSpacesUsed{ pCS ? pCS->m_NumSRVSpacesUsed : 1u }
         {
         }
@@ -183,10 +183,10 @@ namespace D3D12TranslationLayer
         }
 
     private:
-        static UINT NumUAVBindings(Shader* pVS, Shader* pPS, Shader* pGS, Shader* pHS, Shader* pDS)
+        static UINT NumUAVBindings(SShaderDecls const* pVS, SShaderDecls const* pPS, SShaderDecls const* pGS, SShaderDecls const* pHS, SShaderDecls const* pDS)
         {
             UINT MaxUAVCount = 0;
-            Shader* arr[] = { pVS, pPS, pGS, pHS, pDS };
+            SShaderDecls const* arr[] = { pVS, pPS, pGS, pHS, pDS };
             for (auto p : arr)
             {
                 if (p && p->m_UAVDecls.size() > MaxUAVCount)

--- a/include/Shader.hpp
+++ b/include/Shader.hpp
@@ -40,10 +40,15 @@ namespace D3D12TranslationLayer
     {
     public:
 #ifdef SUPPORTS_DXBC_PARSE
+        // Construct with ownership of DXBC, and parse decls
         Shader(ImmediateContext* pParent, std::unique_ptr<BYTE[]> byteCode, SIZE_T bytecodeSize);
-        Shader(ImmediateContext* pParent, const BYTE* byteCode, SIZE_T bytecodeSize);
+        // Construct without ownership of DXBC, and parse decls
+        Shader(ImmediateContext* pParent, const void* byteCode, SIZE_T bytecodeSize);
 #endif
+        // Construct with ownership of DXBC and DXIL, with pre-parsed decls
         Shader(ImmediateContext* pParent, std::unique_ptr<BYTE[]> DXBC, CComHeapPtr<void>& DXIL, SIZE_T dxilSize, SShaderDecls PrecomputedDecls);
+        // Construct without ownership, shader model does not matter, with pre-parsed decls
+        Shader(ImmediateContext* pParent, const void* byteCode, SIZE_T bytecodeSize, SShaderDecls PrecomputedDecls);
 
         UINT OutputStreamMask() { return m_OutputStreamMask; }
         const D3D12_SHADER_BYTECODE& GetByteCode() const{ return m_Desc; }

--- a/src/CommandListManager.cpp
+++ b/src/CommandListManager.cpp
@@ -122,12 +122,15 @@ namespace D3D12TranslationLayer
             // If the GPU is idle, submit work to keep it busy
             if (m_Fence.GetCompletedValue() == m_commandListID - 1)
             {
-                TraceLoggingWrite(g_hTracelogging,
-                                  "OpportunisticFlush",
-                                  TraceLoggingUInt32(m_NumCommands, "NumCommands"),
-                                  TraceLoggingUInt32(m_NumDraws, "NumDraws"),
-                                  TraceLoggingUInt32(m_NumDispatches, "NumDispatches"),
-                                  TraceLoggingUInt64(m_UploadHeapSpaceAllocated, "UploadHeapSpaceAllocated"));
+                if (g_hTracelogging)
+                {
+                    TraceLoggingWrite(g_hTracelogging,
+                                      "OpportunisticFlush",
+                                      TraceLoggingUInt32(m_NumCommands, "NumCommands"),
+                                      TraceLoggingUInt32(m_NumDraws, "NumDraws"),
+                                      TraceLoggingUInt32(m_NumDispatches, "NumDispatches"),
+                                      TraceLoggingUInt64(m_UploadHeapSpaceAllocated, "UploadHeapSpaceAllocated"));
+                }
                 SubmitCommandListImpl();
             }
         }

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -545,11 +545,14 @@ void ImmediateContext::RollOverHeap(OnlineDescriptorHeap& Heap) noexcept(false)
     }
     else
     {
-        TraceLoggingWrite(g_hTracelogging,
-            "HeavyDescriptorHeapUsage",
-            TraceLoggingUInt32(UINT(Heap.m_Desc.Type), "HeapTypeEnum"),
-            TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-            TraceLoggingLevel(TRACE_LEVEL_INFORMATION));
+        if (g_hTracelogging)
+        {
+            TraceLoggingWrite(g_hTracelogging,
+                "HeavyDescriptorHeapUsage",
+                TraceLoggingUInt32(UINT(Heap.m_Desc.Type), "HeapTypeEnum"),
+                TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                TraceLoggingLevel(TRACE_LEVEL_INFORMATION));
+        }
 
         // If we reach this point they are really heavy heap users so we can fall back the roll over strategy
         Heap.m_HeapPool.ReturnToPool(std::move(Heap.m_pDescriptorHeap), GetCommandListID(COMMAND_LIST_TYPE::GRAPHICS));

--- a/src/PipelineState.cpp
+++ b/src/PipelineState.cpp
@@ -112,13 +112,16 @@ namespace D3D12TranslationLayer
         if (FAILED(hr))
         {
             MICROSOFT_TELEMETRY_ASSERT(hr != E_INVALIDARG);
-            TraceLoggingWrite(g_hTracelogging,
-                              "PSOCreationFailure",
-                              TraceLoggingInt32(0, "SchemaVersion"),
-                              TraceLoggingHResult(hr, "HResult"),
-                              TraceLoggingInt32(Type, "PSOType"),
-                              TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
-                              TraceLoggingLevel(TRACE_LEVEL_ERROR));
+            if (g_hTracelogging)
+            {
+                TraceLoggingWrite(g_hTracelogging,
+                                  "PSOCreationFailure",
+                                  TraceLoggingInt32(0, "SchemaVersion"),
+                                  TraceLoggingHResult(hr, "HResult"),
+                                  TraceLoggingInt32(Type, "PSOType"),
+                                  TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES),
+                                  TraceLoggingLevel(TRACE_LEVEL_ERROR));
+            }
         }
         ThrowFailure(hr); // throw( _com_error )
 

--- a/src/Shader.cpp
+++ b/src/Shader.cpp
@@ -14,4 +14,11 @@ namespace D3D12TranslationLayer
         , m_Desc({ m_Dxil, dxilSize })
     {
     }
+
+    Shader::Shader(ImmediateContext* pParent, const void* byteCode, SIZE_T bytecodeSize, SShaderDecls PrecomputedDecls)
+        : DeviceChild(pParent)
+        , SShaderDecls(std::move(PrecomputedDecls))
+        , m_Desc({ byteCode, bytecodeSize })
+    {
+    }
 };

--- a/src/ShaderParser.cpp
+++ b/src/ShaderParser.cpp
@@ -16,7 +16,7 @@ namespace D3D12TranslationLayer
         Init();
     }
 
-    Shader::Shader(ImmediateContext* pParent, const BYTE* byteCode, SIZE_T bytecodeSize)
+    Shader::Shader(ImmediateContext* pParent, const void* byteCode, SIZE_T bytecodeSize)
         : DeviceChild(pParent)
         , m_Desc({ byteCode, bytecodeSize })
     {

--- a/src/VideoDecode.cpp
+++ b/src/VideoDecode.cpp
@@ -784,10 +784,13 @@ namespace D3D12TranslationLayer
         GetStatusReportFeedbackNumber(/*_Out_*/statusReportFeedbackNumber, /*_Out_*/CurrPic, /*_Out_*/field_pic_flag);  // throw( _com_error )
         m_decodingStatus.EndQuery(statusReportFeedbackNumber, CurrPic, field_pic_flag);  // throw( _com_error )
 
-        TraceLoggingWrite(g_hTracelogging,
+        if (g_hTracelogging)
+        {
+            TraceLoggingWrite(g_hTracelogging,
                 "Decode - StatusReportFeedbackNumber",
                 TraceLoggingPointer(m_spVideoDecoder->GetForImmediateUse(), "pID3D12Decoder"),
                 TraceLoggingValue(statusReportFeedbackNumber, "statusReportFeedbackNumber"));
+        }
 
         m_pParent->SubmitCommandList(COMMAND_LIST_TYPE::VIDEO_DECODE);
     }

--- a/src/VideoDecodeStatistics.cpp
+++ b/src/VideoDecodeStatistics.cpp
@@ -184,10 +184,13 @@ namespace D3D12TranslationLayer
                         pStatus->bStatus = VideoDecodeStatusMap[pD3d12VideoStats->Status];
                         pStatus->wNumMbsAffected = (USHORT)pD3d12VideoStats->NumMacroblocksAffected;
 
-                        TraceLoggingWrite(g_hTracelogging,
-                            "GetStatus - StatusReportFeedbackNumber",
-                            TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
-                            TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        if (g_hTracelogging)
+                        {
+                            TraceLoggingWrite(g_hTracelogging,
+                                "GetStatus - StatusReportFeedbackNumber",
+                                TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
+                                TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        }
                     } break;
 
                     case VIDEO_DECODE_PROFILE_TYPE_HEVC:
@@ -202,10 +205,13 @@ namespace D3D12TranslationLayer
                         pStatus->bStatus = VideoDecodeStatusMap[pD3d12VideoStats->Status];
                         pStatus->wNumMbsAffected = (USHORT)pD3d12VideoStats->NumMacroblocksAffected;
 
-                        TraceLoggingWrite(g_hTracelogging,
-                            "GetStatus - StatusReportFeedbackNumber",
-                            TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
-                            TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        if (g_hTracelogging)
+                        {
+                            TraceLoggingWrite(g_hTracelogging,
+                                "GetStatus - StatusReportFeedbackNumber",
+                                TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
+                                TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        }
                     } break;
 
                     case VIDEO_DECODE_PROFILE_TYPE_VP9:
@@ -221,10 +227,13 @@ namespace D3D12TranslationLayer
                         pStatus->bStatus = VideoDecodeStatusMap[pD3d12VideoStats->Status];
                         pStatus->wNumMbsAffected = (USHORT)pD3d12VideoStats->NumMacroblocksAffected;
 
-                        TraceLoggingWrite(g_hTracelogging,
-                            "GetStatus - StatusReportFeedbackNumber",
-                            TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
-                            TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        if (g_hTracelogging)
+                        {
+                            TraceLoggingWrite(g_hTracelogging,
+                                "GetStatus - StatusReportFeedbackNumber",
+                                TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
+                                TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        }
                     } break;
 
                     case VIDEO_DECODE_PROFILE_TYPE_VC1:
@@ -238,10 +247,13 @@ namespace D3D12TranslationLayer
                         pStatus->bStatus = VideoDecodeStatusMap[pD3d12VideoStats->Status];
                         pStatus->wNumMbsAffected = (USHORT)pD3d12VideoStats->NumMacroblocksAffected;
 
-                        TraceLoggingWrite(g_hTracelogging,
-                            "GetStatus - StatusReportFeedbackNumber",
-                            TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
-                            TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));                            
+                        if (g_hTracelogging)
+                        {
+                            TraceLoggingWrite(g_hTracelogging,
+                                "GetStatus - StatusReportFeedbackNumber",
+                                TraceLoggingPointer(pVideoDecoder, "pID3D12Decoder"),
+                                TraceLoggingValue(pStatus->StatusReportFeedbackNumber, "statusReportFeedbackNumber"));
+                        }
                     } break;
 
                     case VIDEO_DECODE_PROFILE_TYPE_MPEG2:           // TODO: can't find info about this one, Srinath is checking.

--- a/src/VideoReferenceDataManager.cpp
+++ b/src/VideoReferenceDataManager.cpp
@@ -71,10 +71,13 @@ namespace D3D12TranslationLayer
             {
                 // Caller specified an invalid reference index.  Remap it to the current
                 // picture index to avoid crashing and still attempt to decode.
-                TraceLoggingWrite(g_hTracelogging,
-                "Decode - Invalid Reference Index",
-                    TraceLoggingValue(index, "Index"),
-                    TraceLoggingValue(m_currentOutputIndex, "OutputIndex"));
+                if (g_hTracelogging)
+                {
+                    TraceLoggingWrite(g_hTracelogging,
+                        "Decode - Invalid Reference Index",
+                        TraceLoggingValue(index, "Index"),
+                        TraceLoggingValue(m_currentOutputIndex, "OutputIndex"));
+                }
 
                 remappedIndex = m_currentOutputIndex;
 
@@ -147,8 +150,11 @@ namespace D3D12TranslationLayer
         if (remappedIndex == m_invalidIndex)
         {
             // No unused entry exists.  Indicates a problem with MaxDPB.
-            TraceLoggingWrite(g_hTracelogging,
-                "Decode - No available reference map entry for output.");
+            if (g_hTracelogging)
+            {
+                TraceLoggingWrite(g_hTracelogging,
+                    "Decode - No available reference map entry for output.");
+            }
             ThrowFailure(E_INVALIDARG);
         }
 


### PR DESCRIPTION
- Add Shader creation method for non-owning non-parsing creation, to enable non-owning DXIL shaders.
- Add null checks for tracelogging handle to prevent crashes if tracelogging is unused.