### PR TITLE
std::result_of -> std::invoke_result to avoid deprecation

### DIFF
--- a/include/Allocator.h
+++ b/include/Allocator.h
@@ -52,7 +52,7 @@ namespace D3D12TranslationLayer
         }
         void Deallocate(const _BlockType &block) { m_InnerAllocator.Deallocate(block.GetDirectHeapAllocation()); }
 
-        typedef typename std::result_of<decltype(&InnerAllocatorDecayed::Allocate)(InnerAllocatorDecayed, _SizeType)>::type AllocationType;
+        typedef typename std::invoke_result<decltype(&InnerAllocatorDecayed::Allocate), InnerAllocatorDecayed, _SizeType>::type AllocationType;
 
         inline bool IsOwner(_In_ const _BlockType &block) const { return block.GetOffset() == 0; }
         AllocationType GetInnerAllocation(const _BlockType &block) const { return block.GetDirectHeapAllocation(); }

--- a/include/BlockAllocators.h
+++ b/include/BlockAllocators.h
@@ -376,7 +376,7 @@ private:
 
     using InnerAllocatorDecayed = typename std::decay<_InnerAllocator>::type;
 public:
-    typedef typename std::result_of<decltype(&InnerAllocatorDecayed::Allocate)(InnerAllocatorDecayed, _SizeType)>::type AllocationType;
+    typedef typename std::invoke_result<decltype(&InnerAllocatorDecayed::Allocate), InnerAllocatorDecayed, _SizeType>::type AllocationType;
 
 private:
     struct RefcountedAllocation


### PR DESCRIPTION
This is deprecated in C++17 and removed in C++20.