### PR TITLE
Remove noisy tracelogging event

### DIFF
--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -545,7 +545,7 @@ void ImmediateContext::RollOverHeap(OnlineDescriptorHeap& Heap) noexcept(false)
     }
     else
     {
-        if (g_hTracelogging)
+        if (g_bUseRingBufferDescriptorHeaps && g_hTracelogging)
         {
             TraceLoggingWrite(g_hTracelogging,
                 "HeavyDescriptorHeapUsage",


### PR DESCRIPTION
Only emit heavy descriptor heap usage event when using ring buffer descriptor heaps.