### PR TITLE
D3D11On12: Clearing an AYUV View Using Incorrect RTV Format

### DIFF
--- a/include/ResourceCache.hpp
+++ b/include/ResourceCache.hpp
@@ -16,7 +16,7 @@ namespace D3D12TranslationLayer
     public:
         ResourceCache(ImmediateContext &device);
 
-        ResourceCacheEntry const& GetResource(DXGI_FORMAT format, UINT width, UINT height);
+        ResourceCacheEntry const& GetResource(DXGI_FORMAT format, UINT width, UINT height, DXGI_FORMAT viewFormat = DXGI_FORMAT_UNKNOWN);
         void TakeCacheEntryOwnership(DXGI_FORMAT format, ResourceCacheEntry& entryOut);
 
         typedef std::map<DXGI_FORMAT, ResourceCacheEntry> DXGIMap;


### PR DESCRIPTION
ClearResourceWithNoRenderTarget always attempted to use the resource format for the RTV format for formats that could support render target.  This doesn't work for AYUV which must use a supported video view:

https://docs.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format

This modifies that code path to use DXGI_FORMAT_R8G8B8A8_UINT for the view format.