### PR TITLE
Synchronization changes to enable D3D11On12 earlier release of memory

### DIFF
--- a/include/Allocator.h
+++ b/include/Allocator.h
@@ -98,7 +98,7 @@ namespace D3D12TranslationLayer
         using DisjointBuddyHeapAllocator::IsOwner;
 
     private:
-        OptLock m_Lock;
+        OptLock<> m_Lock;
     };
 
     // Allocator that will conditionally choose to individually allocate resources or suballocate based on a 

--- a/include/BatchedContext.hpp
+++ b/include/BatchedContext.hpp
@@ -552,8 +552,8 @@ public:
     BatchedContext(ImmediateContext& ImmCtx, CreationArgs flags, Callbacks const& callbacks);
     ~BatchedContext();
 
-    void TRANSLATION_API ProcessBatch();
-    void TRANSLATION_API SubmitBatch(bool bFlushImmCtxAfterBatch = false);
+    bool TRANSLATION_API ProcessBatch();
+    bool TRANSLATION_API SubmitBatch(bool bFlushImmCtxAfterBatch = false);
     Batch::Reference TRANSLATION_API GetCurrentRecordingBatch();
     void TRANSLATION_API SubmitBatchIfIdle();
 
@@ -762,7 +762,7 @@ private:
     template <typename TCmd, typename... Args> void EmplaceInBatch(Args&&... args);
     void ProcessBatchWork(BatchStorage& batch);
 
-    void WaitForBatchThreadIdle();
+    bool WaitForBatchThreadIdle();
     bool IsBatchThreadIdle();
     bool WaitForSingleBatch(DWORD timeout);
     bool IsBatchThread();

--- a/include/BatchedContext.hpp
+++ b/include/BatchedContext.hpp
@@ -14,7 +14,7 @@ struct BatchedExtension
 
 class FreePageContainer
 {
-    OptLock m_CS;
+    OptLock<> m_CS;
     void* m_FreePageHead = nullptr;
 
 public:
@@ -773,7 +773,7 @@ private: // Referenced by recording and batch threads
     SafeHANDLE m_BatchSubmittedSemaphore; // Signaled by recording thread to indicate new work available.
     SafeHANDLE m_BatchConsumedSemaphore; // Signaled by batch thread to indicate it's completed work, waited on by main thread when work submitted.
 
-    OptLock m_SubmissionLock{ m_CreationArgs.SubmitBatchesToWorkerThread }; // Synchronizes the deques and free page list.
+    OptLock<> m_SubmissionLock{ m_CreationArgs.SubmitBatchesToWorkerThread }; // Synchronizes the deques and free page list.
     std::deque<std::unique_ptr<Batch>> m_QueuedBatches;
     std::deque<std::unique_ptr<Batch>> m_FreeBatches;
 
@@ -807,11 +807,11 @@ private: // Referenced by recording thread
 
 private: // Written by non-recording application threads, read by recording thread
     std::atomic<bool> m_bPendingInitialData = false;
-    OptLock m_PreBatchExecutionCS{ m_CreationArgs.CreatesAndDestroysAreMultithreaded };
+    OptLock<> m_PreBatchExecutionCS{ m_CreationArgs.CreatesAndDestroysAreMultithreaded };
     BatchStorage m_PreBatchCommands{ m_BatchStorageAllocator };
 
     std::atomic<bool> m_bPendingDestroys = false;
-    OptLock m_PostBatchExecutionCS{ m_CreationArgs.CreatesAndDestroysAreMultithreaded };;
+    OptLock<> m_PostBatchExecutionCS{ m_CreationArgs.CreatesAndDestroysAreMultithreaded };;
     std::vector<std::function<void()>> m_PostBatchFunctions;
 };
 

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -171,7 +171,7 @@ protected:
 
 protected:
     TMultiPool m_MultiPool;
-    OptLock m_Lock;
+    OptLock<> m_Lock;
     UINT64 m_TrimThreshold;
 };
 
@@ -461,7 +461,7 @@ private: // Members
     const D3D12_DESCRIPTOR_HEAP_DESC m_Desc;
     const UINT m_DescriptorSize;
     ID3D12Device* const m_pDevice; // weak-ref
-    OptLock m_CritSect;
+    OptLock<> m_CritSect;
 
     THeapMap m_Heaps;
     std::list<HeapIndex> m_FreeHeaps;
@@ -720,17 +720,17 @@ private:
     std::queue<RetiredSuballocationBlock> m_DeferredSuballocationDeletionQueue;
 };
 
-template <typename T> class COptLockedContainer
+template <typename T, typename mutex_t = std::mutex> class COptLockedContainer
 {
-    OptLock m_CS;
+    OptLock<mutex_t> m_CS;
     T m_Obj;
 public:
     class LockedAccess
     {
-        std::unique_lock<std::mutex> m_Lock;
+        std::unique_lock<mutex_t> m_Lock;
         T& m_Obj;
     public:
-        LockedAccess(OptLock &CS, T& Obj)
+        LockedAccess(OptLock<mutex_t> &CS, T& Obj)
             : m_Lock(CS.TakeLock())
             , m_Obj(Obj) { }
         T* operator->() { return &m_Obj; }

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -492,13 +492,14 @@ namespace D3D12TranslationLayer
         seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
     }
 
+    template <typename mutex_t = std::mutex>
     class OptLock
     {
-        mutable std::optional<std::mutex> m_Lock;
+        mutable std::optional<mutex_t> m_Lock;
     public:
-        std::unique_lock<std::mutex> TakeLock() const
+        std::unique_lock<mutex_t> TakeLock() const
         {
-            return m_Lock ? std::unique_lock<std::mutex>(*m_Lock) : std::unique_lock<std::mutex>();
+            return m_Lock ? std::unique_lock<mutex_t>(*m_Lock) : std::unique_lock<mutex_t>();
         }
         OptLock(bool bHaveLock = false)
         {

--- a/src/BatchedContext.cpp
+++ b/src/BatchedContext.cpp
@@ -1729,6 +1729,7 @@ void TRANSLATION_API BatchedContext::ProcessBatch()
             m_PostBatchFunctions.clear();
 
             m_CurrentCommandCount = 0;
+            m_PendingDestructionMemorySize = 0;
         });
 
         ProcessBatchWork(m_CurrentBatch); // throws
@@ -1775,6 +1776,7 @@ std::unique_ptr<BatchedContext::Batch> BatchedContext::FinishBatch(bool bFlushIm
         m_CurrentRecordingBatch->PrepareToSubmit(std::move(NewBatch), std::move(NewPostBatchFunctions), bFlushImmCtxAfterBatch);
         pRet = std::move(m_CurrentRecordingBatch);
         m_CurrentCommandCount = 0;
+        m_PendingDestructionMemorySize = 0;
     }
 
     // Synchronize with the worker thread potentially retiring batches


### PR DESCRIPTION
Destruction in D3D11 can be free-threaded. Currently the batched context appends all destructions to the end the current batch. That means that an immediate context operation (most likely an explicit flush) is needed before those resources are moved to the next level of deferral in the immediate context. That means that an app is likelier to run out of memory if it has large resources caught up waiting for this flush.

This change adds a lock to work recording, which has has contention against creation (initial data upload) and enqueueing of destruction. That allows the work batches to be flushed by any application thread. Batches are explicitly sent to the worker thread if they contain destruction of "large" (arbitrarily determined) resources.