### PR TITLE
Fixes for async query GetData checking

### DIFF
--- a/include/BatchedQuery.hpp
+++ b/include/BatchedQuery.hpp
@@ -20,6 +20,6 @@ namespace D3D12TranslationLayer
         Async* FlushBatchAndGetImmediate() { ProcessBatch(); return m_pImmediateAsyncWeak; }
 
         Async::AsyncState m_CurrentState = Async::AsyncState::Ended;
-        BatchedContext::Batch::Reference m_BatchReference;
+        uint64_t m_BatchReferenceID = 0;
     };
 }


### PR DESCRIPTION
There's two things here:
1. The check for worker thread idle in SyncWithBatch is wrong.
2. The use of the batch reference can miss cases where Begin/End are inside a command list.

The first commit is a straightforward fix for the race condition in problem 1.
The second commit is a complex reworking of how references to batches are managed to address problem 2.