### PR TITLE
Add on-by-default CMake option to use PIX for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,6 @@ project(d3d12translationlayer)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(USE_PIX "Enable the use of PIX markers" ON)
+
 add_subdirectory(src)

--- a/include/D3D12TranslationLayerIncludes.h
+++ b/include/D3D12TranslationLayerIncludes.h
@@ -6,7 +6,6 @@
 #define USE_PIX_ON_ALL_ARCHITECTURES
 #endif
 
-#define USE_PIX
 #include <pix3.h>
 
 //Library Headers

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,10 @@ target_link_libraries(d3d12translationlayer WinPixEventRuntime)
 target_compile_definitions(d3d12translationlayer PRIVATE $<$<CONFIG:DEBUG>:DBG>)
 target_compile_definitions(d3d12translationlayer PUBLIC $<$<CONFIG:DEBUG>:TRANSLATION_LAYER_DBG=1>)
 
+if (USE_PIX)
+	target_compile_definitions(d3d12translationlayer PUBLIC USE_PIX)
+endif()
+
 if(MSVC)
   target_compile_options(d3d12translationlayer PUBLIC /W4 /WX /wd4238 /wd4324)
   target_link_options(d3d12translationlayer INTERFACE "/ignore:4286")


### PR DESCRIPTION
Rather than hardcoding in the header, this allows them to be turned off.