### PR TITLE
Don't initialize descriptors during view creation

### DIFF
--- a/include/View.hpp
+++ b/include/View.hpp
@@ -123,7 +123,7 @@ namespace D3D12TranslationLayer
         const TDesc12& GetDesc12() noexcept;
 
         bool IsUpToDate() const noexcept { return m_pResource->GetUniqueness<TIface>() == m_ViewUniqueness; }
-        HRESULT RefreshUnderlying(bool bInit = false) noexcept;
+        HRESULT RefreshUnderlying() noexcept;
 
         void ViewBound(UINT Slot = 0, EShaderStage = e_PS) noexcept;
         void ViewUnbound(UINT Slot = 0, EShaderStage = e_PS) noexcept;

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -79,10 +79,6 @@ namespace D3D12TranslationLayer
             // No more failures after this point
             m_pCounterResource = std::move(pCounterResource);
 
-            // Force the descriptor to be refreshed now that the counter has been allocated
-            hr = RefreshUnderlying(false);
-            assert(S_OK == hr);
-
             // Transition the counter to the UAV state
             D3D12_RESOURCE_BARRIER BarrierDesc;
             ZeroMemory(&BarrierDesc, sizeof(BarrierDesc));


### PR DESCRIPTION
This can end up racing with ops like RotateResourceIdentities, potentially snapping the wrong view uniqueness/resource pairing.