### PR TITLE
Make sure view descriptors are refreshed whenever the descriptor is accessed for binding

### DIFF
--- a/include/ResourceBinding.hpp
+++ b/include/ResourceBinding.hpp
@@ -264,8 +264,7 @@ namespace D3D12TranslationLayer
             {
                 if (this->m_Bound[i])
                 {
-                    this->m_Bound[i]->RefreshUnderlying();
-                    pDescriptors[i] = this->m_Bound[i]->m_Descriptor;
+                    pDescriptors[i] = this->m_Bound[i]->GetRefreshedDescriptorHandle();
                 }
                 else
                 {

--- a/include/View.hpp
+++ b/include/View.hpp
@@ -92,9 +92,12 @@ namespace D3D12TranslationLayer
 
     public: // Members
         Resource* const m_pResource;
+
+    protected:
         D3D12_CPU_DESCRIPTOR_HANDLE m_Descriptor;
         UINT m_DescriptorHeapIndex;
 
+    public:
         CViewSubresourceSubset m_subresources;
         UINT m_ViewUniqueness;
     };
@@ -124,6 +127,16 @@ namespace D3D12TranslationLayer
 
         bool IsUpToDate() const noexcept { return m_pResource->GetUniqueness<TIface>() == m_ViewUniqueness; }
         HRESULT RefreshUnderlying() noexcept;
+        D3D12_CPU_DESCRIPTOR_HANDLE GetRefreshedDescriptorHandle()
+        {
+            HRESULT hr = RefreshUnderlying();
+            if (FAILED(hr))
+            {
+                assert(hr != E_INVALIDARG);
+                ThrowFailure(hr);
+            }
+            return m_Descriptor;
+        }
 
         void ViewBound(UINT Slot = 0, EShaderStage = e_PS) noexcept;
         void ViewUnbound(UINT Slot = 0, EShaderStage = e_PS) noexcept;

--- a/src/BlitHelper.cpp
+++ b/src/BlitHelper.cpp
@@ -330,7 +330,7 @@ namespace D3D12TranslationLayer
         D3D12_GPU_DESCRIPTOR_HANDLE SRVBaseGPU = m_pParent->m_ViewHeap.GPUHandle(SRVBaseSlot);
         pCommandList->SetGraphicsRootDescriptorTable(0, SRVBaseGPU);
 
-        pCommandList->OMSetRenderTargets(1, &pRTV->m_Descriptor, TRUE, nullptr);
+        pCommandList->OMSetRenderTargets(1, &pRTV->GetRefreshedDescriptorHandle(), TRUE, nullptr);
 
         // Constant buffers: srcRect, src dimensions
         {

--- a/src/VideoProcess.cpp
+++ b/src/VideoProcess.cpp
@@ -691,7 +691,7 @@ namespace D3D12TranslationLayer
                 D3D12_GPU_DESCRIPTOR_HANDLE SRVBaseGPU = m_pParent->m_ViewHeap.GPUHandle(SRVBaseSlot);
                 SRVBaseSlot++;
 
-                m_pParent->m_pDevice12->CopyDescriptorsSimple(1, SRVBaseCPU, inputSRV.m_Descriptor, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+                m_pParent->m_pDevice12->CopyDescriptorsSimple(1, SRVBaseCPU, inputSRV.GetRefreshedDescriptorHandle(), D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
                 pCommandList->SetPipelineState(m_spDeinterlacePSOs[ViewFormat]->GetForUse(COMMAND_LIST_TYPE::GRAPHICS));
 
@@ -700,7 +700,7 @@ namespace D3D12TranslationLayer
                 pCommandList->RSSetViewports(1, &Viewport);
                 pCommandList->RSSetScissorRects(1, &Scissor);
 
-                pCommandList->OMSetRenderTargets(1, &outputRTV.m_Descriptor, TRUE, nullptr);
+                pCommandList->OMSetRenderTargets(1, &outputRTV.GetRefreshedDescriptorHandle(), TRUE, nullptr);
                 pCommandList->SetGraphicsRootDescriptorTable(1, SRVBaseGPU);
 
                 pCommandList->DrawInstanced(4, 1, 0, 0);


### PR DESCRIPTION
Otherwise we can end up using uninitialized descriptors if it was assumed that view construction initialized the descriptor.