### PR TITLE
Ensure that D3D12TranslationLayer's command queue manager will flush …

### DIFF
--- a/src/ResourceState.cpp
+++ b/src/ResourceState.cpp
@@ -1060,6 +1060,7 @@ namespace D3D12TranslationLayer
         PostSubmitUpdateState([=](PostApplyUpdate const& update, COMMAND_LIST_TYPE CmdListType, UINT64 FenceValue)
         {
             static_cast<Resource&>(update.AffectedResource).UsedInCommandList(CmdListType, FenceValue);
+            m_ImmCtx.GetCommandListManager(CmdListType)->SetNeedSubmitFence();
         }, CurrentFenceValues, NewCommandListID);
     }
 };


### PR DESCRIPTION
…if a resource requires a given fence value

This can happen in a corner case where a simultaneous-access resource is transitioning, e.g. because of a keyed mutex release.
We mark the resource as only needing to be "used" in the command list if a concrete barrier is needed.
We think that a concrete barrier is needed, and tentatively put the resource in the barrier list.
But later, we end up flushing the command list for a different barrier, so we discard the barrier.
However, that resource is still in the list of resources that should be considered "used" in the current command list.
Later, if no other commands are enqueued before this resource needs to be used, we can end up waiting for a fence value that'll never be signaled,
because the command list manager has no commands, and doesn't know that anybody has a dependency on the given fence value.

As a workaround, we just always make sure that the command list manager will signal a fence if we've introduced a new dependency on a given fence value.