### PR TITLE
Add residency pinning for UnwrapUnderlyingResource

### DIFF
--- a/include/Resource.hpp
+++ b/include/Resource.hpp
@@ -896,5 +896,13 @@ namespace D3D12TranslationLayer
         }
 
         bool m_isValid = false;
+
+        // Fence used to ensure residency operations queued as part of UnwrapUnderlyingResource
+        // operations are completed if the caller returns a resource without scheduling any work.
+        DeferredWait m_UnwrapUnderlyingResidencyDeferredWait;
+
+public:
+        HRESULT AddFenceForUnwrapResidency(ID3D12CommandQueue* pQueue);
+
     };
 };

--- a/include/d3dx12Residency.h
+++ b/include/d3dx12Residency.h
@@ -151,7 +151,7 @@ namespace D3DX12Residency
 			m_pinWaits.reserve(m_pinWaits.size() + NumSync); // throw( bad_alloc);
 			for (UINT i(0); i < NumSync; ++i)
 			{
-				m_pinWaits.push_back(PinWait( ppFences[i], pSignalValues[i] ));
+				m_pinWaits.emplace_back(ppFences[i], pSignalValues[i]);
 			}
 		}
 
@@ -160,7 +160,8 @@ namespace D3DX12Residency
 			m_pinWaits.erase(std::remove_if(m_pinWaits.begin(), m_pinWaits.end(), [](auto& pinWait)
 				{
 					return (pinWait.m_pFence->GetCompletedValue() >= pinWait.m_value);
-				}));
+				}), 
+				m_pinWaits.end());
 
 			return m_pinWaits.size() > 0;
 		}
@@ -713,13 +714,14 @@ namespace D3DX12Residency
 						break;
 					}
 
+					RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
+
 					if (pObject->IsPinned())
 					{
 						pResourceEntry = pResourceEntry->Flink;
 					}
 					else
 					{
-						RESIDENCY_CHECK(pObject->ResidencyStatus == ManagedObject::RESIDENCY_STATUS::RESIDENT);
 						EvictionList[NumObjectsToEvict++] = pObject->pUnderlying;
 						Evict(pObject);
 


### PR DESCRIPTION
This change adds support to residency management for pinning a resource.  Pinning prevents resources from being evicted by trim activities when under memory pressure.  Used initially by UnwrapUnderlyingResource to prevent application checked out resources from being evicted while in use by the caller.