### PR TITLE
Add flag which causes blits from YUY2 to use [0,0.5] coords instead of [0,1]

### DIFF
--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -846,6 +846,7 @@ public:
         UINT UseResidencyManagement : 1;
         UINT DisableGPUTimeout : 1;
         UINT IsXbox : 1;
+        UINT AdjustYUY2BlitCoords : 1;
         GUID CreatorID;
     };
 

--- a/src/BlitHelper.cpp
+++ b/src/BlitHelper.cpp
@@ -337,6 +337,13 @@ namespace D3D12TranslationLayer
             UINT subresourceIndex = pSrcSubresourceIndices[0];
             auto& srcSubresourceFootprint = pSrc->GetSubresourcePlacement(subresourceIndex).Footprint;
             int srcPositions[6] = { srcRect.left, srcRect.right, srcRect.top, srcRect.bottom, (int)srcSubresourceFootprint.Width, (int)srcSubresourceFootprint.Height };
+
+            if (srcSubresourceFootprint.Format == DXGI_FORMAT_YUY2 &&
+                m_pParent->m_CreationArgs.AdjustYUY2BlitCoords)
+            {
+                srcPositions[4] *= 2;
+            }
+
             pCommandList->SetGraphicsRoot32BitConstants(1, _countof(srcPositions), &srcPositions[0], 0);
         }
 


### PR DESCRIPTION
Some hardware handles this incorrectly.