### PR TITLE
Also force batch flushing for destruction of shared resources

### DIFF
--- a/include/BatchedContext.hpp
+++ b/include/BatchedContext.hpp
@@ -558,7 +558,8 @@ public:
         auto Size = pResource->GetResourceSize();
         m_PostBatchFunctions.emplace_back([pResource]() { pResource->Release(); });
         m_PendingDestructionMemorySize += Size;
-        if (m_PendingDestructionMemorySize >= 64 * 1024 * 1024)
+        if (m_PendingDestructionMemorySize >= 64 * 1024 * 1024 ||
+            pResource->Parent()->IsShared())
         {
             SubmitBatch();
         }


### PR DESCRIPTION
This helps keep them from sticking around too long, which can cause problems in some cases.