### PR TITLE
Wait for the last write state transition for a resource when transitioning to a shared read state.

### DIFF
--- a/src/ResourceState.cpp
+++ b/src/ResourceState.cpp
@@ -759,6 +759,14 @@ namespace D3D12TranslationLayer
         {
             after |= SharedState.State[(UINT)m_DestinationCommandListType];
             assert(!IsD3D12WriteState(after, SubresourceTransitionFlags::None));
+
+            auto& ExclusiveState = CurrentState.GetExclusiveSubresourceState(i);
+            if (ExclusiveState.CommandListType != COMMAND_LIST_TYPE::UNKNOWN)
+            {
+                m_QueueFenceValuesToWaitOn[(UINT)ExclusiveState.CommandListType] =
+                    std::max(m_QueueFenceValuesToWaitOn[(UINT)ExclusiveState.CommandListType],
+                            ExclusiveState.FenceValue);
+            }
         }
 
         if (bQueueStateUpdate)


### PR DESCRIPTION

Wait for the last write state transition for a resource when transitioning to a shared read state.

Prior to this change, only the next transition to a shared read state would wait for the write to complete. In the repro, a resource is used in an exclusive write state for decode output. Then the resource was used as a reference in a subsequent decode and as input to a video process operation. If the decode came first, it would transition to a shared read state and wait for the write to complete, but the subsequent video process operation would not.