### PR TITLE
Don't re-insert the same synchronization over and over

### DIFF
--- a/include/ResourceState.hpp
+++ b/include/ResourceState.hpp
@@ -239,6 +239,8 @@ constexpr D3D12_RESOURCE_STATES RESOURCE_STATE_ALL_WRITE_BITS =
         bool m_bFlushQueues[(UINT)COMMAND_LIST_TYPE::MAX_VALID];
         UINT64 m_QueueFenceValuesToWaitOn[(UINT)COMMAND_LIST_TYPE::MAX_VALID];
 
+        UINT64 m_InsertedQueueSync[(UINT)COMMAND_LIST_TYPE::MAX_VALID][(UINT)COMMAND_LIST_TYPE::MAX_VALID] = {};
+
         ResourceStateManagerBase() noexcept(false);
 
         ~ResourceStateManagerBase() noexcept


### PR DESCRIPTION
Keep track of which cross-queue synchronization has been done so we don't re-do it over and over. Also don't try to synchronize a queue to itself.