### PR TITLE
SharedFenceSignal use removed.  ShouldFlushForResourceAcquire check for more than dispatches/draws

### DIFF
--- a/include/CommandListManager.hpp
+++ b/include/CommandListManager.hpp
@@ -25,7 +25,7 @@ namespace D3D12TranslationLayer
         void SetNeedSubmitFence() noexcept { m_bNeedSubmitFence = true; }
         bool HasCommands() const noexcept { return m_NumCommands > 0; }
         bool NeedSubmitFence() const noexcept { return m_bNeedSubmitFence; }
-        bool ShouldFlushForResourceAcquire() const noexcept { return m_NumDraws > 0 || m_NumDispatches > 0; }
+        bool ShouldFlushForResourceAcquire() const noexcept { return HasCommands() || NeedSubmitFence(); }
         template <typename TFunc> void ExecuteCommandQueueCommand(TFunc&& func)
         {
             m_bNeedSubmitFence = true;

--- a/src/ResourceState.cpp
+++ b/src/ResourceState.cpp
@@ -949,7 +949,8 @@ namespace D3D12TranslationLayer
             auto pSharingContract = pDestinationManager->GetSharingContract();
             for (auto& Wait : m_DeferredWaits)
             {
-                if (pSharingContract)
+                if (   pSharingContract 
+                    && (Wait.fence->Get()->GetCreationFlags() & D3D12_FENCE_FLAG_SHARED) != 0)
                 {
                     // Note, this is not when the fence is actually signaled during a standard app run.
                     // However, for tools purposes, they need to know that the fence will be signaled before the wait is inserted,

--- a/src/ResourceState.cpp
+++ b/src/ResourceState.cpp
@@ -946,18 +946,8 @@ namespace D3D12TranslationLayer
             [this, ppManagers](COMMAND_LIST_TYPE type)
         {
             auto pDestinationManager = ppManagers[(UINT)type];
-            auto pSharingContract = pDestinationManager->GetSharingContract();
             for (auto& Wait : m_DeferredWaits)
             {
-                if (   pSharingContract 
-                    && (Wait.fence->Get()->GetCreationFlags() & D3D12_FENCE_FLAG_SHARED) != 0)
-                {
-                    // Note, this is not when the fence is actually signaled during a standard app run.
-                    // However, for tools purposes, they need to know that the fence will be signaled before the wait is inserted,
-                    // to prevent a deadlock during playback. The timing of this signal doesn't really matter, all that matters
-                    // is the ordering.
-                    pSharingContract->SharedFenceSignal(Wait.fence->Get(), Wait.value);
-                }
                 pDestinationManager->GetCommandQueue()->Wait(Wait.fence->Get(), Wait.value);
                 Wait.fence->UsedInCommandList(pDestinationManager->GetCommandListType(), pDestinationManager->GetCommandListID());
             }


### PR DESCRIPTION
-SharedFenceSignal was called for non-shared fences. SharedFenceSignal use is deprecated, so remove entirely. 

-ShouldFlushForResourceAcquire only checked draws and dispatches which could lead to deadlocks with UnwrapUnderlyingResource.