### PR TITLE
Add support for uploading B10G10R10A2 data to an R10G10B10A2 texture

### DIFF
--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -925,6 +925,9 @@ public:
         ScenarioBatchedContext,             // Servicing a queued operation, but may be occurring in parallel with immediate context operations
         ScenarioImmediateContextInternalOp, // Servicing an internal immediate context operation (e.g. updating UAV/SO counters) and should not respect predication
         ScenarioMask = 0x3,
+
+        None = 0,
+        ChannelSwapR10G10B10A2 = 0x4,
     };
     void UpdateSubresources(Resource* pDst,
                             D3D12TranslationLayer::CSubresourceSubset const& Subresources,
@@ -998,8 +1001,8 @@ public:
         bool NeedToRespectPredication(UpdateSubresourcesFlags flags) const;
         bool NeedTemporaryUploadHeap(UpdateSubresourcesFlags flags, ImmediateContext& ImmCtx) const;
         void InitializeMappableResource(UpdateSubresourcesFlags flags, ImmediateContext& ImmCtx, D3D12_BOX const* pDstBox);
-        void UploadSourceDataToMappableResource(void* pDstData, D3D11_SUBRESOURCE_DATA const* pSrcData, ImmediateContext& ImmCtx);
-        void UploadDataToMappableResource(D3D11_SUBRESOURCE_DATA const* pSrcData, ImmediateContext& ImmCtx, D3D12_BOX const* pDstBox, const void* pClearPattern, UINT ClearPatternSize);
+        void UploadSourceDataToMappableResource(void* pDstData, D3D11_SUBRESOURCE_DATA const* pSrcData, ImmediateContext& ImmCtx, UpdateSubresourcesFlags flags);
+        void UploadDataToMappableResource(D3D11_SUBRESOURCE_DATA const* pSrcData, ImmediateContext& ImmCtx, D3D12_BOX const* pDstBox, const void* pClearPattern, UINT ClearPatternSize, UpdateSubresourcesFlags flags);
         void WriteOutputParameters(D3D12_BOX const* pDstBox, UpdateSubresourcesFlags flags);
     };
     void FinalizeUpdateSubresources(Resource* pDst, PreparedUpdateSubresourcesOperation const& PreparedStorage, _In_reads_opt_(2) D3D12_PLACED_SUBRESOURCE_FOOTPRINT const* LocalPlacementDescs);

--- a/src/BatchedContext.cpp
+++ b/src/BatchedContext.cpp
@@ -1078,7 +1078,7 @@ void TRANSLATION_API BatchedContext::ResourceUpdateSubresourceUP(Resource* pReso
         CSubresourceSubset(1, 1, pResource->SubresourceMultiplier(), MipLevel, ArraySlice, PlaneSlice),
         &SubresourceDesc,
         pDstBox,
-        ImmediateContext::UpdateSubresourcesScenario::BatchedContext,
+        ImmediateContext::UpdateSubresourcesFlags::ScenarioBatchedContext,
         nullptr, 0, m_ImmCtx);
 
     if (PrepareHelper.FinalizeNeeded) // Might be a no-op due to box.
@@ -1103,7 +1103,7 @@ void TRANSLATION_API BatchedContext::UploadInitialData(Resource* pDst, D3D12Tran
         Subresources,
         pSrcData,
         pDstBox,
-        ImmediateContext::UpdateSubresourcesScenario::InitialData,
+        ImmediateContext::UpdateSubresourcesFlags::ScenarioInitialData,
         nullptr,
         0,
         m_ImmCtx);


### PR DESCRIPTION
D3D9On12 has a scenario where it needs to upload CPU data straight in the B10G10R10A2 format (`D3DFMT_A2R10G10B10`) into a D3D12 R10G10B10A2 texture, since D3D12 doesn't have a format for the channel-swapped variant. Normally, D3D9On12 uses shader techniques to do the channel swap, but this scenario doesn't have the data in a GPU-visible format already before the swap needs to happen.