### PR TITLE
[Video Decode] Change reference pictures DPB eviction policy for codecs MPEG2 and VC1

### DIFF
--- a/include/VideoReferenceDataManager.hpp
+++ b/include/VideoReferenceDataManager.hpp
@@ -42,8 +42,9 @@ namespace D3D12TranslationLayer
     
         void Resize(UINT16 dbp, _In_opt_ ReferenceOnlyDesc* pReferenceOnly, bool fArrayOfTexture);
         
-        void ResetAllUsage();
-        
+        void ResetInternalTrackingReferenceUsage();
+        void ResetReferenceFramesInformation();
+
         template<typename T, size_t size> 
         void MarkReferencesInUse(const T (&picEntries)[size]);
         void MarkReferenceInUse(UINT16 index);

--- a/src/VideoReferenceDataManager.cpp
+++ b/src/VideoReferenceDataManager.cpp
@@ -234,7 +234,8 @@ namespace D3D12TranslationLayer
         m_fArrayOfTexture = fArrayOfTexture;
 
         ResizeDataStructures(dpb);
-        ResetAllUsage();
+        ResetInternalTrackingReferenceUsage();
+        ResetReferenceFramesInformation();
         ReleaseUnusedReferences();
 
         m_fReferenceOnly = pReferenceOnly != nullptr;
@@ -296,14 +297,21 @@ namespace D3D12TranslationLayer
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------
-    void ReferenceDataManager::ResetAllUsage()
+    void ReferenceDataManager::ResetReferenceFramesInformation()
     {
         for (UINT index = 0; index < Size(); index++)
         {
             textures[index] = nullptr;
             texturesSubresources[index] = 0;
             decoderHeapsParameter[index] = nullptr;
+        }
+    }
 
+    //----------------------------------------------------------------------------------------------------------------------------------
+    void ReferenceDataManager::ResetInternalTrackingReferenceUsage()
+    {
+        for (UINT index = 0; index < Size(); index++)
+        {
             referenceDatas[index].fUsed = false;
         }
     }


### PR DESCRIPTION
There was an issue with some MPEG2 and VC1 videos that have the following pattern:

1) Decode a couple frames and add them to DPB for usage as reference pictures in future frames
2) Decode a frame that doesn't use reference frames. **At this point the DPB is emptied by the translation layer.**
3) Decode a frame that used references from frames decoded in step (1) and emptied in step (2). At this point ReferenceDataManager::UpdateEntry issues "Decode - Invalid Reference Index" and remaps it to the current
                // picture index to avoid crashing and still attempt to decode.

This pull request changes the DPB eviction strategy for MPEG2 and VC1, by keeping alive the reference pictures from previous frames when the current frame doesn't use any reference pictures, but still evicts as before when the frame uses >= 1 references

Tests show no regressions after this change and the bug doesn't repro anymore.