### PR TITLE
Blit helper now resolves msaa resource to non msaa

### DIFF
--- a/include/BlitHelper.hpp
+++ b/include/BlitHelper.hpp
@@ -37,5 +37,10 @@ namespace D3D12TranslationLayer
         ImmediateContext* const m_pParent;
         std::unordered_map<UINT, std::unique_ptr<BlitPipelineState>> m_spBlitPSOs;
         std::unique_ptr<InternalRootSignature> m_spRootSig;
+
+    private:
+        //pResource will be updated to point at the resolved resource if it was originally an MSAA resource
+        //subresourceIndices will be updated to reflect the resolved resource's subresource indecies if pResource was originally an MSAA resource
+        void ResolveToNonMsaaIfNeeded( _Inout_ Resource **ppResource, _Inout_ std::vector<UINT> &subresourceIndices, const RECT &srcRect );
     };
 };

--- a/include/BlitHelper.hpp
+++ b/include/BlitHelper.hpp
@@ -39,9 +39,8 @@ namespace D3D12TranslationLayer
         std::unique_ptr<InternalRootSignature> m_spRootSig;
 
     private:
-        //@param ppResource: will be updated to point at the resolved resource if it was originally an MSAA resource
-        //@param pSubresourceIndices: will be updated to reflect the resolved resource's subresource indecies if pResource was originally an MSAA resource
-        //@return True if a resolve was performed
-        bool ResolveToNonMsaaIfNeeded( _Inout_ Resource **ppResource, UINT* pSubresourceIndices, UINT numSubresources, const RECT &srcRect );
+        //@param ppResource: will be updated to point at the resolved resource
+        //@param pSubresourceIndices: will be updated to reflect the resolved resource's subresource indecies
+        void ResolveToNonMsaa( _Inout_ Resource **ppResource, _Inout_ UINT* pSubresourceIndices, UINT numSubresources, const RECT &srcRect );
     };
 };

--- a/include/BlitHelper.hpp
+++ b/include/BlitHelper.hpp
@@ -39,8 +39,9 @@ namespace D3D12TranslationLayer
         std::unique_ptr<InternalRootSignature> m_spRootSig;
 
     private:
-        //pResource will be updated to point at the resolved resource if it was originally an MSAA resource
-        //subresourceIndices will be updated to reflect the resolved resource's subresource indecies if pResource was originally an MSAA resource
-        void ResolveToNonMsaaIfNeeded( _Inout_ Resource **ppResource, _Inout_ std::vector<UINT> &subresourceIndices, const RECT &srcRect );
+        //@param ppResource: will be updated to point at the resolved resource if it was originally an MSAA resource
+        //@param pSubresourceIndices: will be updated to reflect the resolved resource's subresource indecies if pResource was originally an MSAA resource
+        //@return True if a resolve was performed
+        bool ResolveToNonMsaaIfNeeded( _Inout_ Resource **ppResource, UINT* pSubresourceIndices, UINT numSubresources, const RECT &srcRect );
     };
 };


### PR DESCRIPTION
BlitHelper doesn't support blitting MSAA textures, so now we will check
if the source was an MSAA texture and then resolve it to a non msaa
texture if needed before performing the blit.