### PR TITLE
Switch to using DirectX-Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,17 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14)
 project(d3d12translationlayer)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+FetchContent_Declare(
+    DirectX-Headers
+    GIT_REPOSITORY https://github.com/Microsoft/DirectX-Headers.git
+    GIT_TAG 53d22f0256832f4a36117386355d54e2331127de
+)
+FetchContent_MakeAvailable(DirectX-Headers)
 
 option(USE_PIX "Enable the use of PIX markers" ON)
 

--- a/include/D3D12TranslationLayerDependencyIncludes.h
+++ b/include/D3D12TranslationLayerDependencyIncludes.h
@@ -19,11 +19,11 @@
 
 #define INITGUID
 #include <guiddef.h>
-#include <d3d12video.h>
-#include <dxcore.h>
+#include <directx/d3d12video.h>
+#include <directx/dxcore.h>
 #undef INITGUID
-#include <d3d12compatibility.h>
-#include <d3dx12.h>
+#include <directx/d3d12compatibility.h>
+#include <directx/d3dx12.h>
 #include <d3d11_3.h>
 #include <dxgi1_5.h>
 

--- a/include/D3D12TranslationLayerIncludes.h
+++ b/include/D3D12TranslationLayerIncludes.h
@@ -18,6 +18,7 @@
 
 #include <BlockAllocators.h>
 #include "Allocator.h"
+#include "XPlatHelpers.h"
 
 #include <ThreadPool.hpp>
 #include <segmented_stack.h>

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -801,6 +801,9 @@ public:
     // D3D12 objects
     // TODO: const
     const unique_comptr<ID3D12Device> m_pDevice12;
+#if DYNAMIC_LOAD_DXCORE
+    XPlatHelpers::unique_module m_DXCore;
+#endif
     unique_comptr<IDXCoreAdapter> m_pDXCoreAdapter;
     unique_comptr<IDXGIAdapter3> m_pDXGIAdapter;
     unique_comptr<ID3D12Device1> m_pDevice12_1;

--- a/include/XPlatHelpers.h
+++ b/include/XPlatHelpers.h
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+namespace XPlatHelpers
+{
+#ifdef _WIN32
+    using Event = HANDLE;
+    constexpr Event InvalidEvent = nullptr;
+    inline void SetEvent(Event e) { ::SetEvent(e); }
+    inline Event CreateEvent() { return ::CreateEvent(nullptr, false, false, nullptr); }
+    inline bool WaitForEvent(Event e, DWORD timeoutMs) { return WaitForSingleObject(e, timeoutMs) == WAIT_OBJECT_0; }
+    inline bool WaitForEvent(Event e) { return WaitForEvent(e, INFINITE); }
+    inline Event DuplicateEvent(Event e)
+    {
+        Event eNew = nullptr;
+        (void)DuplicateHandle(GetCurrentProcess(), e, GetCurrentProcess(), &eNew, 0, FALSE, DUPLICATE_SAME_ACCESS);
+        return eNew;
+    }
+    inline void CloseEvent(Event e) { CloseHandle(e); }
+    inline Event EventFromHANDLE(HANDLE h) { return h; }
+#else
+    using Event = int;
+    constexpr Event InvalidEvent = -1;
+    inline void SetEvent(Event e) { eventfd_write(e, 1); }
+    inline Event CreateEvent() { return eventfd(0, 0); }
+    inline bool WaitForEvent(Event e)
+    {
+        eventfd_t val;
+        return eventfd_read(e, &val) == 0;
+    }
+    inline bool WaitForEvent(Event e, int timeoutMs)
+    {
+        pollfd fds = { e, POLLIN, 0 };
+        if (poll(&fds, 1, timeoutMs) && (fds.revents & POLLIN))
+        {
+            return WaitForEvent(e);
+        }
+        return false;
+    }
+    inline Event DuplicateEvent(Event e) { return dup(e); }
+    inline void CloseEvent(Event e) { close(e); }
+    inline Event EventFromHANDLE(HANDLE h)
+    {
+        return static_cast<int>(reinterpret_cast<intptr_t>(h));
+    }
+#endif
+
+    class unique_event
+    {
+        Event m_event = InvalidEvent;
+    public:
+        struct copy_tag {};
+        unique_event() = default;
+        unique_event(Event e) : m_event(e) { }
+        unique_event(Event e, copy_tag) : m_event(DuplicateEvent(e)) { }
+        unique_event(unique_event&& e) : m_event(e.detach()) { }
+        unique_event& operator=(unique_event&& e)
+        {
+            close();
+            m_event = e.detach();
+            return *this;
+        }
+        ~unique_event() { close(); }
+        void close()
+        {
+            if (*this)
+            {
+                CloseEvent(m_event);
+            }
+            m_event = InvalidEvent;
+        }
+        void reset(Event e = InvalidEvent) { close(); m_event = e; }
+        void create() { reset(CreateEvent()); }
+        Event get() { return m_event; }
+        Event detach() { Event e = m_event; m_event = InvalidEvent; return e; }
+        void set() const { SetEvent(m_event); }
+        bool poll() const { return WaitForEvent(m_event, 0); }
+        void wait() const { WaitForEvent(m_event); }
+        operator bool() const { return m_event != InvalidEvent; }
+    };
+
+    // This class relies on the fact that modules are void* in both, and using the same Windows API names in the Linux Windows.h.
+    class unique_module
+    {
+        HMODULE _hM = nullptr;
+    public:
+        unique_module() = default;
+        explicit unique_module(HMODULE hM) : _hM(hM) { }
+        explicit unique_module(const char* pCStr) : _hM(LoadLibraryA(pCStr)) { }
+#ifdef _WIN32
+        explicit unique_module(const wchar_t* pWStr) : _hM(LoadLibraryW(pWStr)) { }
+#else
+        explicit unique_module(const wchar_t* pWStr)
+            : _hM(LoadLibraryA(std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(pWStr).c_str()))
+        {   
+        }
+#endif
+
+        void reset(HMODULE hM = nullptr)
+        {
+            if (_hM)
+                FreeLibrary(_hM);
+            _hM = hM;
+        }
+        void load(const char* pCStr) { reset(LoadLibraryA(pCStr)); }
+#ifdef _WIN32
+        void load(const wchar_t* pWStr) { reset(LoadLibraryW(pWStr)); }
+#else
+        void load(const wchar_t* pWStr) { *this = unique_module(pWStr); }
+#endif
+        HMODULE detach()
+        {
+            HMODULE hM = _hM;
+            _hM = nullptr;
+            return hM;
+        }
+
+        ~unique_module() { reset(); }
+        unique_module(unique_module&& o) : _hM(o.detach()) { }
+        unique_module& operator=(unique_module&& o)
+        {
+            reset(o.detach());
+            return *this;
+        }
+
+        HMODULE* get_for_external_load()
+        {
+            reset();
+            return &_hM;
+        }
+        HMODULE get() const { return _hM; }
+        operator bool() const { return _hM != nullptr; }
+
+        void* proc_address(const char* pCStr) const { return GetProcAddress(_hM, pCStr); }
+        template <typename T> T proc_address(const char* pCStr) const { return reinterpret_cast<T>(proc_address(pCStr)); }
+    };
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,10 @@ target_include_directories(d3d12translationlayer
     PUBLIC ../external
     PUBLIC ../include
     PRIVATE ./)
+
+if (CMAKE_VERSION VERSION_GREATER 3.16)
+	target_precompile_headers(d3d12translationlayer PRIVATE ../include/pch.h)
+endif()
     
 source_group(Inlines FILES ${INL})
 source_group("Header Files\\External" FILES ${EXTERNAL_INC})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 cmake_minimum_required(VERSION 3.13)
+include(CheckCXXSourceCompiles)
 
 set(SRC
 	Allocator.cpp
@@ -96,7 +97,21 @@ endif()
 source_group(Inlines FILES ${INL})
 source_group("Header Files\\External" FILES ${EXTERNAL_INC})
 
-target_link_libraries(d3d12translationlayer Microsoft::DirectX-Headers d3d12 dxcore dxgi atls dxbcparser)
+target_link_libraries(d3d12translationlayer Microsoft::DirectX-Headers d3d12 dxgi atls dxbcparser)
+
+# Using a compile test instead of find_library so this doesn't have to be run from a VS command prompt
+check_cxx_source_compiles("
+#pragma comment(lib, \"dxcore.lib\")
+#include <dxcore.h>
+int main() {
+	IDXCoreAdapterFactory *fac;
+	return DXCoreCreateAdapterFactory(&fac);
+}" HAVE_DXCORE_LIBRARY)
+if (HAVE_DXCORE_LIBRARY)
+	target_link_libraries(d3d12translationlayer dxcore)
+else()
+	target_compile_definitions(d3d12translationlayer PRIVATE DYNAMIC_LOAD_DXCORE=1)
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../packages.config ${CMAKE_CURRENT_BINARY_DIR}/packages.config COPYONLY)
 add_library(WinPixEventRuntime INTERFACE IMPORTED GLOBAL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 source_group(Inlines FILES ${INL})
 source_group("Header Files\\External" FILES ${EXTERNAL_INC})
 
-target_link_libraries(d3d12translationlayer d3d12 dxcore dxgi atls dxbcparser)
+target_link_libraries(d3d12translationlayer Microsoft::DirectX-Headers d3d12 dxcore dxgi atls dxbcparser)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../packages.config ${CMAKE_CURRENT_BINARY_DIR}/packages.config COPYONLY)
 add_library(WinPixEventRuntime INTERFACE IMPORTED GLOBAL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ int main() {
 }" HAVE_DXCORE_LIBRARY)
 if (HAVE_DXCORE_LIBRARY)
 	target_link_libraries(d3d12translationlayer dxcore)
+	target_link_options(d3d12translationlayer INTERFACE "/DELAYLOAD:dxcore.dll")
 else()
 	target_compile_definitions(d3d12translationlayer PRIVATE DYNAMIC_LOAD_DXCORE=1)
 endif()

--- a/src/CommandListManager.cpp
+++ b/src/CommandListManager.cpp
@@ -38,7 +38,6 @@ namespace D3D12TranslationLayer
             queue.NodeMask = m_pParent->GetNodeMask();
             queue.Flags = m_pParent->m_CreationArgs.DisableGPUTimeout ?
                 D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT : D3D12_COMMAND_QUEUE_FLAG_NONE;
-#ifdef __ID3D12Device9_INTERFACE_DEFINED__
             CComPtr<ID3D12Device9> spDevice9;
             if (SUCCEEDED(m_pParent->m_pDevice12->QueryInterface(&spDevice9)))
             {
@@ -46,11 +45,8 @@ namespace D3D12TranslationLayer
             }
             else
             {
-#endif
                 ThrowFailure(m_pParent->m_pDevice12->CreateCommandQueue(&queue, IID_PPV_ARGS(&m_pCommandQueue)));
-#ifdef __ID3D12Device9_INTERFACE_DEFINED__
             }
-#endif
         }
 
         PrepareNewCommandList();

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -134,7 +134,13 @@ ImmediateContext::ImmediateContext(UINT nodeIndex, D3D12_FEATURE_DATA_D3D12_OPTI
     LUID adapterLUID = pDevice->GetAdapterLuid();
     {
         CComPtr<IDXCoreAdapterFactory> pFactory;
+#if DYNAMIC_LOAD_DXCORE
+        m_DXCore.load("dxcore");
+        auto pfnDXCoreCreateAdapterFactory = m_DXCore.proc_address<HRESULT(APIENTRY*)(REFIID, void**)>("DXCoreCreateAdapterFactory");
+        if (m_DXCore && pfnDXCoreCreateAdapterFactory && SUCCEEDED(pfnDXCoreCreateAdapterFactory(IID_PPV_ARGS(&pFactory))))
+#else
         if (SUCCEEDED(DXCoreCreateAdapterFactory(IID_PPV_ARGS(&pFactory))))
+#endif
         {
             (void)pFactory->GetAdapterByLuid(adapterLUID, IID_PPV_ARGS(&m_pDXCoreAdapter));
         }


### PR DESCRIPTION
This change makes this project use DirectX-Headers for D3D12 and DXCore headers instead of relying on getting them from the SDK. That does 2 things:
1. Means we can compile-time depend on new APIs being available - obviously runtime still needs to potentially handle them not being there.
2. Means this library no longer depends on an insider SDK, since the DXCore headers are now included, and the library is made optional.