### PR TITLE
Use Win32 lean and mean (+wincrypt.h)

### DIFF
--- a/include/D3D12TranslationLayerDependencyIncludes.h
+++ b/include/D3D12TranslationLayerDependencyIncludes.h
@@ -11,11 +11,15 @@
 
 //SDK Headers
 #define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #define _ATL_NO_WIN_SUPPORT
 #include <windows.h>
 #include <atlbase.h>
 #include <comdef.h>
 #include <strsafe.h>
+
+// This defines NTSTATUS and other types that are needed for kernel headers
+#include <wincrypt.h>
 
 #define INITGUID
 #include <guiddef.h>


### PR DESCRIPTION
This simplifies header dependencies. Rather than pulling in all the Windows.h bloat, we can just pull in the main stuff and wincrypt.h for its NTSTATUS definition.