### PR TITLE
Fix BlitHelper::ResolveToNonMsaa

### DIFF
--- a/include/BlitHelper.hpp
+++ b/include/BlitHelper.hpp
@@ -41,6 +41,6 @@ namespace D3D12TranslationLayer
     private:
         //@param ppResource: will be updated to point at the resolved resource
         //@param pSubresourceIndices: will be updated to reflect the resolved resource's subresource indecies
-        void ResolveToNonMsaa( _Inout_ Resource **ppResource, _Inout_ UINT* pSubresourceIndices, UINT numSubresources, const RECT &srcRect );
+        void ResolveToNonMsaa( _Inout_ Resource **ppResource, _Inout_ UINT* pSubresourceIndices, UINT numSubresources );
     };
 };

--- a/src/BlitHelper.cpp
+++ b/src/BlitHelper.cpp
@@ -176,7 +176,7 @@ namespace D3D12TranslationLayer
         if (pSrc->AppDesc()->Samples() > 1)
         {
             assert( !needsTwoPassColorConvert ); //Can't have MSAA YUV resources, so this should be false
-            ResolveToNonMsaa( &pSrc /*inout*/, nonMsaaSrcSubresourceIndices /*inout*/, numSrcSubresources, srcRect );
+            ResolveToNonMsaa( &pSrc /*inout*/, nonMsaaSrcSubresourceIndices /*inout*/, numSrcSubresources );
 
             // We used a Cache Entry of pSrc's format to do the resolve. 
             // If pDst uses the same format and we need a temp render target, 
@@ -413,12 +413,15 @@ namespace D3D12TranslationLayer
         m_pParent->PostRender(COMMAND_LIST_TYPE::GRAPHICS, e_GraphicsStateDirty);
     }
 
-    void BlitHelper::ResolveToNonMsaa( _Inout_ Resource **ppResource, _Inout_ UINT* pSubresourceIndices, UINT numSubresources, const RECT& srcRect )
+    void BlitHelper::ResolveToNonMsaa( _Inout_ Resource **ppResource, _Inout_ UINT* pSubresourceIndices, UINT numSubresources )
     {
         auto pResource = *ppResource;
         assert( numSubresources == 1 ); // assert that it's only 1 because you can't have MSAA YUV resources.
 
-        auto& cacheEntry = m_pParent->GetResourceCache().GetResource( pResource->AppDesc()->Format(), RectWidth( srcRect ), RectHeight( srcRect ) );
+        auto srcDesc = pResource->GetUnderlyingResource()->GetDesc();
+        UINT width = static_cast<UINT>(srcDesc.Width);
+        UINT height = static_cast<UINT>(srcDesc.Height);
+        auto& cacheEntry = m_pParent->GetResourceCache().GetResource( pResource->AppDesc()->Format(), width, height );
         auto pCacheResource = cacheEntry.m_Resource.get();
         for (UINT i = 0; i < numSubresources; i++)
         {


### PR DESCRIPTION
D3D12's ResolveSubresource expects the destination dimensions
to be as large or larger than the source (taking into account msaa
scaling). The apps we were testing with happened to call blit with a
source Rect of matching dimensions, so when we created our intermediate
resource in ResolveToNonMsaa we had the appropriate size. This doesn't
work when the app only blits a section of the source resource though. In
this case our intermediate resource ends up being too small and the
resolve fails. The solution is to create an intermediate resource of the
same size as the source resource's underlying d3d12 resource.