### PR TITLE
Use per-plane map refcounts instead of just a bitmask

### DIFF
--- a/include/Resource.hpp
+++ b/include/Resource.hpp
@@ -882,10 +882,10 @@ namespace D3D12TranslationLayer
         // to Map and Unmap.
         struct DynamicTexturePlaneData
         {
-            DynamicTexturePlaneData() :m_MappedPlaneMask(0), m_DirtyPlaneMask(0) {}
+            UINT8 m_MappedPlaneRefCount[3] = {};
+            UINT8 m_DirtyPlaneMask = 0;
 
-            UINT m_MappedPlaneMask : 4;
-            UINT m_DirtyPlaneMask : 4;
+            bool AnyPlaneMapped() const { return (*reinterpret_cast<const UINT32*>(this) & 0xffffff) != 0; }
         };
 
         PreallocatedArray<DynamicTexturePlaneData> m_DynamicTexturePlaneData;


### PR DESCRIPTION
This was originally written with D3D11 in mind, which will block recursive maps, but D3D9 (and older) will let them through. This fixes a bug with double-unmap attempting to access a null pRenameResource.

Also fix the calls to actually map the heaps to use subresource index instead of plane index.