### PR TITLE
Revert PlaneIndex => Subresource change

### DIFF
--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -4381,7 +4381,7 @@ bool TRANSLATION_API ImmediateContext::MapDynamicTexture(Resource* pResource, UI
         assert(pRenameResource->AppDesc()->MipLevels() == 1);
         assert(pRenameResource->AppDesc()->ArraySize() == 1);
 
-        if (!MapUnderlyingSynchronize(pRenameResource, Subresource, MapType, DoNotWait, pReadWriteRange, pMap))
+        if (!MapUnderlyingSynchronize(pRenameResource, PlaneIndex, MapType, DoNotWait, pReadWriteRange, pMap))
         {
             return false;
         }


### PR DESCRIPTION
I'd missed the two asserts and comment above which should've clued me in that the originally requested subresource isn't valid to use for this map resource. Instead, it needs to be just the plane index, which is the right subresource for this map resource.