### PR TITLE
Allow setting of MaxAllocatedUploadSpacePerCommandList

### DIFF
--- a/include/CommandListManager.hpp
+++ b/include/CommandListManager.hpp
@@ -111,6 +111,13 @@ namespace D3D12TranslationLayer
         bool                                                m_bNeedSubmitFence;
         ThrowingSafeHandle                                  m_hWaitEvent;
 
+        // The more upload heap space allocated in a command list, the more memory we are 
+        // potentially holding up that could have been recycled into the pool. If too
+        // much is held up, flush the command list
+        static constexpr UINT cMaxAllocatedUploadHeapSpacePerCommandList = 256 * 1024 * 1024;
+
+        DWORD                                               m_MaxAllocatedUploadHeapSpacePerCommandList;
+
         // Command allocator pools
         CFencePool< unique_comptr<ID3D12CommandAllocator> > m_AllocatorPool;
 

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -851,6 +851,7 @@ public:
         UINT IsXbox : 1;
         UINT AdjustYUY2BlitCoords : 1;
         GUID CreatorID;
+        DWORD MaxAllocatedUploadHeapSpacePerCommandList;
     };
 
     ImmediateContext(UINT nodeIndex, D3D12_FEATURE_DATA_D3D12_OPTIONS& caps,

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -852,6 +852,7 @@ public:
         UINT AdjustYUY2BlitCoords : 1;
         GUID CreatorID;
         DWORD MaxAllocatedUploadHeapSpacePerCommandList;
+        DWORD MaxSRVHeapSize;
     };
 
     ImmediateContext(UINT nodeIndex, D3D12_FEATURE_DATA_D3D12_OPTIONS& caps,

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -170,7 +170,7 @@ ImmediateContext::ImmediateContext(UINT nodeIndex, D3D12_FEATURE_DATA_D3D12_OPTI
     m_UAVDeclScratch.reserve(D3D11_1_UAV_SLOT_COUNT); // throw( bad_alloc )
     m_vUAVBarriers.reserve(D3D11_1_UAV_SLOT_COUNT); // throw( bad_alloc )
 
-    m_ViewHeap.m_MaxHeapSize = D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1;
+    m_ViewHeap.m_MaxHeapSize = min((DWORD) D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1, m_CreationArgs.MaxSRVHeapSize);
     const UINT32 viewHeapStartingCount = m_bUseRingBufferDescriptorHeaps ? 4096 : m_ViewHeap.m_MaxHeapSize;
     m_ViewHeap.m_DescriptorRingBuffer = CFencedRingBuffer(viewHeapStartingCount);
     m_ViewHeap.m_Desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -585,6 +585,7 @@ namespace D3D12TranslationLayer
                         IID_PPV_ARGS(&m_Identity->m_spUnderlyingResource));
                 }
                 const UINT D3D11_BIND_CAPTURE = 0x800;
+                UNREFERENCED_PARAMETER(D3D11_BIND_CAPTURE);
                 assert(hr != E_INVALIDARG || (Flags11.BindFlags & D3D11_BIND_CAPTURE));
                 ThrowFailure(hr); // throw( _com_error )
             }, threadingContext);

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -584,8 +584,7 @@ namespace D3D12TranslationLayer
                         nullptr, // Clear values
                         IID_PPV_ARGS(&m_Identity->m_spUnderlyingResource));
                 }
-                const UINT D3D11_BIND_CAPTURE = 0x800;
-                UNREFERENCED_PARAMETER(D3D11_BIND_CAPTURE);
+                [[maybe_unused]] const UINT D3D11_BIND_CAPTURE = 0x800;
                 assert(hr != E_INVALIDARG || (Flags11.BindFlags & D3D11_BIND_CAPTURE));
                 ThrowFailure(hr); // throw( _com_error )
             }, threadingContext);

--- a/src/VideoDecode.cpp
+++ b/src/VideoDecode.cpp
@@ -934,6 +934,8 @@ namespace D3D12TranslationLayer
             // In progressive - scan frame - structured coding such as in H.261, bPicStructure is 3. 
             // A derived value PicCurrentField is defined as zero unless bPicStructure is 2 (bottom field).In which case, it is 1. 
             // This member has the same meaning as the picture_structure variable defined in Section 6.3.10 and Table 6 - 14 of MPEG - 2 (H.262).
+            [[maybe_unused]] constexpr BYTE TOP_FIELD = 1;
+            [[maybe_unused]] constexpr BYTE BOTTOM_FIELD = 2;
             constexpr BYTE FRAME_PICTURE = 3;
             
             // sample field picture has half as many macroblocks as frame

--- a/src/VideoDecode.cpp
+++ b/src/VideoDecode.cpp
@@ -934,8 +934,6 @@ namespace D3D12TranslationLayer
             // In progressive - scan frame - structured coding such as in H.261, bPicStructure is 3. 
             // A derived value PicCurrentField is defined as zero unless bPicStructure is 2 (bottom field).In which case, it is 1. 
             // This member has the same meaning as the picture_structure variable defined in Section 6.3.10 and Table 6 - 14 of MPEG - 2 (H.262).
-            constexpr BYTE TOP_FIELD = 1;
-            constexpr BYTE BOTTOM_FIELD = 2;
             constexpr BYTE FRAME_PICTURE = 3;
             
             // sample field picture has half as many macroblocks as frame


### PR DESCRIPTION
Add ability to provide MaxAllocatedUploadSpacePerCommandList via ImmediateContext creation args.
Add ability to provide MaxSRVHeapSize via ImmediateContext creation args.
Fix compiler warnings found with VS 2022.