### PR TITLE
When max SRV heap size is 0 from upper layer args, use a reasonable default

### DIFF
--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -171,6 +171,8 @@ ImmediateContext::ImmediateContext(UINT nodeIndex, D3D12_FEATURE_DATA_D3D12_OPTI
     m_vUAVBarriers.reserve(D3D11_1_UAV_SLOT_COUNT); // throw( bad_alloc )
 
     m_ViewHeap.m_MaxHeapSize = min((DWORD) D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1, m_CreationArgs.MaxSRVHeapSize);
+    if (m_ViewHeap.m_MaxHeapSize == 0)
+        m_ViewHeap.m_MaxHeapSize = D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1;
     const UINT32 viewHeapStartingCount = m_bUseRingBufferDescriptorHeaps ? 4096 : m_ViewHeap.m_MaxHeapSize;
     m_ViewHeap.m_DescriptorRingBuffer = CFencedRingBuffer(viewHeapStartingCount);
     m_ViewHeap.m_Desc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;


### PR DESCRIPTION
Fixes a regression from a74474d1d9a7d358768b202ab2bd2198b7f023b6 when used with D3D11On12/OpenCLOn12 which don't set this arg (clearing the struct to 0s).