### PR TITLE
Fix for USE_PIX cmake option not working.

### DIFF
--- a/include/D3D12TranslationLayerIncludes.h
+++ b/include/D3D12TranslationLayerIncludes.h
@@ -6,7 +6,9 @@
 #define USE_PIX_ON_ALL_ARCHITECTURES
 #endif
 
+#if USE_PIX
 #include <pix3.h>
+#endif
 
 //Library Headers
 #define TRANSLATION_API

--- a/include/ImmediateContext.inl
+++ b/include/ImmediateContext.inl
@@ -371,7 +371,10 @@ inline void TRANSLATION_API ImmediateContext::DrawAuto()
 
     try
     {
+#if USE_PIX
         PIXScopedEvent(GetGraphicsCommandList(), 0ull, L"DrawAuto");
+#endif
+
         EnsureDrawAutoResources(); // throw( _com_error )
 
         EnsureExecuteIndirectResources(); // throw( _com_error )
@@ -493,7 +496,10 @@ inline void ImmediateContext::InsertUAVBarriersIfNeeded(CViewBoundState<UAV, D3D
 //----------------------------------------------------------------------------------------------------------------------------------
 inline void ImmediateContext::PreDraw() noexcept(false)
 {
+#if USE_PIX
     PIXScopedEvent(GetGraphicsCommandList(), 0ull, L"PreDraw");
+#endif
+		
     PreRender(COMMAND_LIST_TYPE::GRAPHICS);
 
     if (m_bUseRingBufferDescriptorHeaps)
@@ -1081,7 +1087,10 @@ inline void TRANSLATION_API ImmediateContext::DispatchIndirect(Resource* pBuffer
 //----------------------------------------------------------------------------------------------------------------------------------
 inline void ImmediateContext::PreDispatch() noexcept(false)
 {
+#if USE_PIX
     PIXScopedEvent(GetGraphicsCommandList(), 0ull, L"PreDispatch");
+#endif
+		
     PreRender(COMMAND_LIST_TYPE::GRAPHICS);
 
     if (m_bUseRingBufferDescriptorHeaps)
@@ -1402,7 +1411,10 @@ inline void ImmediateContext::ResetCommandList(UINT commandListTypeMask) noexcep
 //----------------------------------------------------------------------------------------------------------------------------------
 inline HRESULT ImmediateContext::EnqueueSetEvent(UINT commandListTypeMask, HANDLE hEvent) noexcept
 {
+#if USE_PIX
     PIXSetMarker(0ull, L"EnqueueSetEvent");
+#endif
+
     HRESULT hr = S_OK;
     ID3D12Fence *pFences[(UINT)COMMAND_LIST_TYPE::MAX_VALID] = {};
     UINT64 FenceValues[(UINT)COMMAND_LIST_TYPE::MAX_VALID] = {};

--- a/src/CommandListManager.cpp
+++ b/src/CommandListManager.cpp
@@ -456,7 +456,9 @@ namespace D3D12TranslationLayer
     {
         ThrowFailure(EnqueueSetEvent(m_hWaitEvent));
 
+#if USE_PIX
         PIXNotifyWakeFromFenceSignal(m_hWaitEvent);
+#endif			
         DWORD waitRet = WaitForSingleObject(m_hWaitEvent, INFINITE);
         UNREFERENCED_PARAMETER(waitRet);
         assert(waitRet == WAIT_OBJECT_0);
@@ -514,7 +516,10 @@ namespace D3D12TranslationLayer
         }
 #endif
 
+#if USE_PIX
         PIXNotifyWakeFromFenceSignal(m_hWaitEvent);
+#endif				
+				
         DWORD waitRet = WaitForSingleObject(m_hWaitEvent, INFINITE);
         UNREFERENCED_PARAMETER(waitRet);
         assert(waitRet == WAIT_OBJECT_0);

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -809,8 +809,10 @@ namespace D3D12TranslationLayer
     // Copies data into m_spPredicationBuffer and formats it with a compute shader if necessary
     void Query::FillPredicationBuffer()
     {
+#if USE_PIX
         PIXSetMarker(m_pParent->GetGraphicsCommandList(), 0ull, L"Transform query data for predication");
-
+#endif
+		
         // This buffer is created when the query is created
         assert(m_spPredicationBuffer[(UINT)COMMAND_LIST_TYPE::GRAPHICS]);
         assert(m_CommandListTypeMask == COMMAND_LIST_TYPE_GRAPHICS_MASK);


### PR DESCRIPTION
While this option was included in cmake, the required ``#if USE_PIX [...] #endif`` were missing inside the C++ code.

This is required for the x86 build, as the pix nuget package appears to be x64 only.
