### PR TITLE
Removed noexcept from SubmitCommandList and WaitForFenceValue

### DIFF
--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -879,14 +879,14 @@ public:
     HRESULT EnqueueSetEvent(UINT commandListTypeMask, HANDLE hEvent) noexcept;
     HRESULT EnqueueSetEvent(COMMAND_LIST_TYPE commandListType, HANDLE hEvent) noexcept;
     Fence *GetFence(COMMAND_LIST_TYPE type) noexcept;
-    void SubmitCommandList(UINT commandListTypeMask) noexcept;
-    void SubmitCommandList(COMMAND_LIST_TYPE commandListType) noexcept;
+    void SubmitCommandList(UINT commandListTypeMask); // Can't be marked as noexcept as SubmitCommandList(Impl) -> CommandListManager::CloseCommandList(...) throws
+    void SubmitCommandList(COMMAND_LIST_TYPE commandListType); // Can't be marked as noexcept as SubmitCommandList(Impl) -> CommandListManager::CloseCommandList(...) throws
 
     // Returns true if synchronization was successful, false likely means device is removed
     bool WaitForCompletion(UINT commandListTypeMask) noexcept;
     bool WaitForCompletion(COMMAND_LIST_TYPE commandListType) noexcept;
     bool WaitForFenceValue(COMMAND_LIST_TYPE commandListType, UINT64 FenceValue) noexcept;
-    bool WaitForFenceValue(COMMAND_LIST_TYPE type, UINT64 FenceValue, bool DoNotWait) noexcept;
+    bool WaitForFenceValue(COMMAND_LIST_TYPE type, UINT64 FenceValue, bool DoNotWait); // Can't be marked as noexcept as SubmitCommandList throws
 
     ID3D12GraphicsCommandList *GetGraphicsCommandList() noexcept;
     ID3D12VideoDecodeCommandList2 *GetVideoDecodeCommandList() noexcept;

--- a/include/ImmediateContext.inl
+++ b/include/ImmediateContext.inl
@@ -1488,23 +1488,23 @@ inline bool ImmediateContext::WaitForFenceValue(COMMAND_LIST_TYPE commandListTyp
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
-inline void ImmediateContext::SubmitCommandList(UINT commandListTypeMask) noexcept
+inline void ImmediateContext::SubmitCommandList(UINT commandListTypeMask)
 {
     for (UINT i = 0; i < (UINT)COMMAND_LIST_TYPE::MAX_VALID; i++)
     {
         if ((commandListTypeMask & (1 << i))  &&  m_CommandLists[i])
         {
-            m_CommandLists[i]->SubmitCommandList();
+            m_CommandLists[i]->SubmitCommandList(); // throws
         }
     }
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
-inline void ImmediateContext::SubmitCommandList(COMMAND_LIST_TYPE commandListType) noexcept
+inline void ImmediateContext::SubmitCommandList(COMMAND_LIST_TYPE commandListType)
 {
     if (commandListType != COMMAND_LIST_TYPE::UNKNOWN  &&  m_CommandLists[(UINT)commandListType])
     {
-        m_CommandLists[(UINT)commandListType]->SubmitCommandList();
+        m_CommandLists[(UINT)commandListType]->SubmitCommandList(); // throws
     }
 }
 

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -802,7 +802,7 @@ void ImmediateContext::PostRender(COMMAND_LIST_TYPE type, UINT64 ReassertBitsToA
 #if DBG
     if (m_DebugFlags & Debug_FlushOnRender  && HasCommands(type))
     {
-        SubmitCommandList(type);
+        SubmitCommandList(type); // throws
     }
 #else
     UNREFERENCED_PARAMETER(type);
@@ -817,7 +817,7 @@ void ImmediateContext::PostDraw()
 #if DBG
     if (m_DebugFlags & Debug_FlushOnDraw && HasCommands(COMMAND_LIST_TYPE::GRAPHICS))
     {
-       SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);
+       SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);  // throws
     }
 #endif
 }
@@ -830,7 +830,7 @@ void ImmediateContext::PostDispatch()
 #if DBG
     if (m_DebugFlags & Debug_FlushOnDispatch && HasCommands(COMMAND_LIST_TYPE::GRAPHICS))
     {
-        SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);
+        SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);  // throws
     }
 #endif
 }
@@ -1041,7 +1041,7 @@ void ImmediateContext::PostCopy(Resource *pSrc, UINT srcSubresource, Resource *p
 #if DBG
     if (m_DebugFlags & Debug_FlushOnCopy && HasCommands(COMMAND_LIST_TYPE::GRAPHICS))
     {
-        SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);
+        SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);  // throws
     }
 #endif
 }
@@ -1053,7 +1053,7 @@ void ImmediateContext::PostUpload()
 #if DBG
     if (m_DebugFlags & Debug_FlushOnDataUpload && HasCommands(COMMAND_LIST_TYPE::GRAPHICS))
     {
-        SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);
+        SubmitCommandList(COMMAND_LIST_TYPE::GRAPHICS);  // throws
     }
 #endif
 }
@@ -3412,7 +3412,7 @@ void ImmediateContext::UpdateTileMappingsImpl(
 
     if (NeedToSubmit &&  (Flags & TILE_MAPPING_NO_OVERWRITE) == 0 && HasCommands(commandListType))
     {
-        SubmitCommandList(commandListType);
+        SubmitCommandList(commandListType);  // throws
     }
 
     pResource->UsedInCommandList(commandListType, GetCommandListID(commandListType));
@@ -3706,7 +3706,7 @@ void ImmediateContext::CopyTileMappingsImpl(COMMAND_LIST_TYPE commandListType, R
     auto pSrc = pSrcTiledResource->GetUnderlyingResource();
     if ((Flags & TILE_MAPPING_NO_OVERWRITE) == 0 && HasCommands(commandListType))
     {
-        SubmitCommandList(commandListType);
+        SubmitCommandList(commandListType); // throws
     }
 
     pDstTiledResource->UsedInCommandList(commandListType, GetCommandListID(commandListType));
@@ -4495,13 +4495,13 @@ bool ImmediateContext::SynchronizeForMap(Resource* pResource, UINT Subresource, 
 
 
 //----------------------------------------------------------------------------------------------------------------------------------
-bool ImmediateContext::WaitForFenceValue(COMMAND_LIST_TYPE type, UINT64 FenceValue, bool DoNotWait)  noexcept
+bool ImmediateContext::WaitForFenceValue(COMMAND_LIST_TYPE type, UINT64 FenceValue, bool DoNotWait)
 {
     if (DoNotWait)
     {
         if (FenceValue == GetCommandListID(type))
         {
-            SubmitCommandList(type);
+            SubmitCommandList(type); // throws on CommandListManager::CloseCommandList(...)
         }
         if (FenceValue > GetCompletedFenceValue(type))
         {

--- a/src/Query.cpp
+++ b/src/Query.cpp
@@ -133,8 +133,22 @@ namespace D3D12TranslationLayer
                     {
                         return false;
                     }
-                    m_pParent->SubmitCommandList(commandListType);
+                    
+                    // convert exceptions to bool result as method is noexcept and SubmitCommandList throws
+                    try
+                    {
+                        m_pParent->SubmitCommandList(commandListType); // throws
+                    }
+                    catch (_com_error&)
+                    {
+                        ret = false;
+                    }
+                    catch (std::bad_alloc&)
+                    {
+                        ret = false;
+                    }
                 }
+
                 UINT64 LastCompletedFence = m_pParent->GetCompletedFenceValue(commandListType);
                 if (LastCompletedFence < m_EndedCommandListID[listType])
                 {

--- a/src/VideoDecode.cpp
+++ b/src/VideoDecode.cpp
@@ -826,7 +826,7 @@ namespace D3D12TranslationLayer
                 TraceLoggingValue(statusReportFeedbackNumber, "statusReportFeedbackNumber"));
         }
 
-        m_pParent->SubmitCommandList(COMMAND_LIST_TYPE::VIDEO_DECODE);
+        m_pParent->SubmitCommandList(COMMAND_LIST_TYPE::VIDEO_DECODE);  // throws
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------

--- a/src/VideoProcess.cpp
+++ b/src/VideoProcess.cpp
@@ -174,7 +174,7 @@ namespace D3D12TranslationLayer
             &pOutputArguments->D3D12OutputStreamArguments,
             NumInputStreamsForVPBlit,
             pInputArguments->D3D12InputStreamArguments.data());
-        m_pParent->SubmitCommandList(COMMAND_LIST_TYPE::VIDEO_PROCESS);
+        m_pParent->SubmitCommandList(COMMAND_LIST_TYPE::VIDEO_PROCESS);  // throws
 
         // now Blit remaining streams (if needed)
         if (NumInputStreamsForVPBlit < NumInputStreams)


### PR DESCRIPTION
Fix for cases where exceptions are "escaping" a stack trace with a no-except method in between when calling SubmitCommandList

For example:

void VideoDecode::DecodeFrame
is calling
inline void ImmediateContext::SubmitCommandList(COMMAND_LIST_TYPE commandListType) **noexcept**
and this delegates to (different namespace, same fn name)
void CommandListManager::SubmitCommandList()
...
throw in CloseCommandList(...)

Removed noexcept from SubmitCommandList and WaitForFenceValue.
Adapted noexcept callers of this functions to convert the possible exceptions to appropiate return values