### PR TITLE
Add debug check for DXBC blob size

### DIFF
--- a/src/DxbcBuilder.cpp
+++ b/src/DxbcBuilder.cpp
@@ -61,6 +61,14 @@ HRESULT CDXBCBuilder::AppendBlob(DXBCFourCC BlobFourCC, UINT BlobSize, const voi
     }
     // Initialize node
 
+#ifdef DBG
+    if (BlobSize % 4 != 0)
+    {
+        OutputDebugString("Blobsize should be a multiple of 4!");
+        DebugBreak();
+    }
+#endif
+
     // Check what the new total output container size will be.
     UINT NewTotalSize = m_TotalOutputContainerSize + BlobSize +
                         4 /*container index entry*/ + sizeof(DXBCBlobHeader) /* blob header */;


### PR DESCRIPTION
DXBC blobs should be a multiple of 4 bytes.
This isn't a hard requirement, but in case something changes and we need
to debug it, having a check to remind us could help.