### PR TITLE
CommandListManager/ImmediateContext: Limit in-flight Video Decode operations to 16 and wait on CPU when pool is full

### DIFF
--- a/include/CommandListManager.hpp
+++ b/include/CommandListManager.hpp
@@ -131,11 +131,15 @@ namespace D3D12TranslationLayer
         UINT64 m_commandListID = 1;
 
         // Number of maximum in-flight command lists at a given time
-        static constexpr UINT cMaxInFlightDepth[(size_t) COMMAND_LIST_TYPE::MAX_VALID] =
+        static constexpr UINT GetMaxInFlightDepth(COMMAND_LIST_TYPE type)
         {
-            CBoundedFencePool< unique_comptr<ID3D12CommandAllocator> >::cDefaultMaxInFlightDepth, // GRAPHICS
-            16, // VIDEO_DECODE
-            CBoundedFencePool< unique_comptr<ID3D12CommandAllocator> >::cDefaultMaxInFlightDepth // VIDEO_PROCESS
+            switch (type)
+            {
+                case COMMAND_LIST_TYPE::VIDEO_DECODE:
+                    return 16;
+                default:
+                    return 1024;
+            }
         };
 
         void SubmitFence() noexcept;

--- a/include/CommandListManager.hpp
+++ b/include/CommandListManager.hpp
@@ -122,13 +122,21 @@ namespace D3D12TranslationLayer
         DWORD                                               m_MaxAllocatedUploadHeapSpacePerCommandList;
 
         // Command allocator pools
-        CFencePool< unique_comptr<ID3D12CommandAllocator> > m_AllocatorPool;
+        CBoundedFencePool< unique_comptr<ID3D12CommandAllocator> > m_AllocatorPool;
 
         // Some notes on threading related to this command list ID / fence value.
         // The fence value is and should only ever be written by the immediate context thread.
         // The immediate context thread may read the fence value through GetCommandListID().
         // Other threads may read this value, but should only do so via CommandListIDInterlockedRead().
         UINT64 m_commandListID = 1;
+
+        // Number of maximum in-flight command lists at a given time
+        static constexpr UINT cMaxInFlightDepth[(size_t) COMMAND_LIST_TYPE::MAX_VALID] =
+        {
+            CBoundedFencePool< unique_comptr<ID3D12CommandAllocator> >::cDefaultMaxInFlightDepth, // GRAPHICS
+            16, // VIDEO_DECODE
+            CBoundedFencePool< unique_comptr<ID3D12CommandAllocator> >::cDefaultMaxInFlightDepth // VIDEO_PROCESS
+        };
 
         void SubmitFence() noexcept;
         void CloseCommandList(ID3D12CommandList *pCommandList);

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -84,7 +84,7 @@ public:
         }
     }
 
-    CBoundedFencePool(bool bLock = false, UINT MaxInFlightDepth = cDefaultMaxInFlightDepth) noexcept
+    CBoundedFencePool(bool bLock = false, UINT MaxInFlightDepth = UINT_MAX) noexcept
         : m_pLock(bLock ? new std::mutex : nullptr),
         m_MaxInFlightDepth(MaxInFlightDepth)
     {
@@ -102,8 +102,6 @@ public:
         m_MaxInFlightDepth = other.m_MaxInFlightDepth;
         return *this;
     }
-
-    static constexpr UINT cDefaultMaxInFlightDepth = 1024;
 
 protected:
     typedef std::pair<UINT64, TResourceType> TPoolEntry;

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -14,110 +14,6 @@ struct TranslationLayerCallbacks
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // A pool of objects that are recycled on specific fence values
-// with a maximum depth before blocking on RetrieveFromPool
-// This class assumes single threaded caller
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename TResourceType>
-class CBoundedFencePool
-{
-public:
-    void ReturnToPool(TResourceType&& Resource, UINT64 FenceValue) noexcept
-    {
-        try
-        {
-            auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
-            m_Pool.emplace_back(FenceValue, std::move(Resource)); // throw( bad_alloc )
-        }
-        catch (std::bad_alloc&)
-        {
-            // Just drop the error
-            // All uses of this pool use unique_comptr, which will release the resource
-        }
-    }
-
-    template <typename PFNWaitForFenceValue, typename PFNCreateNew, typename... CreationArgType>
-    TResourceType RetrieveFromPool(UINT64 CurrentFenceValue, PFNWaitForFenceValue pfnWaitForFenceValue, PFNCreateNew pfnCreateNew, const CreationArgType&... CreationArgs) noexcept(false)
-    {
-        auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
-        TPool::iterator Head = m_Pool.begin();
-
-        if (Head == m_Pool.end())
-        {
-            return std::move(pfnCreateNew(CreationArgs...)); // throw( _com_error )
-        }
-        else if (CurrentFenceValue < Head->first)
-        {
-            if (m_Pool.size() < m_MaxInFlightDepth)
-            {
-                return std::move(pfnCreateNew(CreationArgs...)); // throw( _com_error )
-            }
-            else
-            {
-                pfnWaitForFenceValue(Head->first); // throw( _com_error )
-            }
-        }
-
-        assert(Head->second);
-        TResourceType ret = std::move(Head->second);
-        m_Pool.erase(Head);
-        return std::move(ret);
-    }
-
-    void Trim(UINT64 TrimThreshold, UINT64 CurrentFenceValue)
-    {
-        auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
-
-        TPool::iterator Head = m_Pool.begin();
-
-        if (Head == m_Pool.end() || (CurrentFenceValue < Head->first))
-        {
-            return;
-        }
-
-        UINT64 difference = CurrentFenceValue - Head->first;
-
-        if (difference >= TrimThreshold)
-        {
-            // only erase one item per 'pump'
-            assert(Head->second);
-            m_Pool.erase(Head);
-        }
-    }
-
-    CBoundedFencePool(bool bLock = false, UINT MaxInFlightDepth = UINT_MAX) noexcept
-        : m_pLock(bLock ? new std::mutex : nullptr),
-        m_MaxInFlightDepth(MaxInFlightDepth)
-    {
-    }
-    CBoundedFencePool(CBoundedFencePool&& other) noexcept
-    {
-        m_Pool = std::move(other.m_Pool);
-        m_pLock = std::move(other.m_pLock);
-        m_MaxInFlightDepth = other.m_MaxInFlightDepth;
-    }
-    CBoundedFencePool& operator=(CBoundedFencePool&& other) noexcept
-    {
-        m_Pool = std::move(other.m_Pool);
-        m_pLock = std::move(other.m_pLock);
-        m_MaxInFlightDepth = other.m_MaxInFlightDepth;
-        return *this;
-    }
-
-protected:
-    typedef std::pair<UINT64, TResourceType> TPoolEntry;
-    typedef std::list<TPoolEntry> TPool;
-
-    CBoundedFencePool(CBoundedFencePool const& other) = delete;
-    CBoundedFencePool& operator=(CBoundedFencePool const& other) = delete;
-
-protected:
-    TPool m_Pool;
-    std::unique_ptr<std::mutex> m_pLock;
-    UINT m_MaxInFlightDepth;
-};
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// A pool of objects that are recycled on specific fence values
 // This class assumes single threaded caller
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename TResourceType>
@@ -130,7 +26,7 @@ public:
         {
             auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
             m_Pool.emplace_back(FenceValue, std::move(Resource)); // throw( bad_alloc )
-        } 
+        }
         catch (std::bad_alloc&)
         {
             // Just drop the error
@@ -201,6 +97,66 @@ protected:
 protected:
     TPool m_Pool;
     std::unique_ptr<std::mutex> m_pLock;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// A pool of objects that are recycled on specific fence values
+// with a maximum depth before blocking on RetrieveFromPool
+// This class assumes single threaded caller
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template<typename TResourceType>
+class CBoundedFencePool : public CFencePool<TResourceType>
+{
+public:
+
+    template <typename PFNWaitForFenceValue, typename PFNCreateNew, typename... CreationArgType>
+    TResourceType RetrieveFromPool(UINT64 CurrentFenceValue, PFNWaitForFenceValue pfnWaitForFenceValue, PFNCreateNew pfnCreateNew, const CreationArgType&... CreationArgs) noexcept(false)
+    {
+        auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
+        TPool::iterator Head = m_Pool.begin();
+
+        if (Head == m_Pool.end())
+        {
+            return std::move(pfnCreateNew(CreationArgs...)); // throw( _com_error )
+        }
+        else if (CurrentFenceValue < Head->first)
+        {
+            if (m_Pool.size() < m_MaxInFlightDepth)
+            {
+                return std::move(pfnCreateNew(CreationArgs...)); // throw( _com_error )
+            }
+            else
+            {
+                pfnWaitForFenceValue(Head->first); // throw( _com_error )
+            }
+        }
+
+        assert(Head->second);
+        TResourceType ret = std::move(Head->second);
+        m_Pool.erase(Head);
+        return std::move(ret);
+    }
+
+    CBoundedFencePool(bool bLock = false, UINT MaxInFlightDepth = UINT_MAX) noexcept
+        : CFencePool(bLock),
+        m_MaxInFlightDepth(MaxInFlightDepth)
+    {
+    }
+    CBoundedFencePool(CBoundedFencePool&& other) noexcept
+        : CFencePool(other),
+        m_MaxInFlightDepth(other.m_MaxInFlightDepth)
+    {
+    }
+    CBoundedFencePool& operator=(CBoundedFencePool&& other) noexcept
+    {
+        m_Pool = std::move(other.m_Pool);
+        m_pLock = std::move(other.m_pLock);
+        m_MaxInFlightDepth = other.m_MaxInFlightDepth;
+        return *this;
+    }
+
+protected:
+    UINT m_MaxInFlightDepth;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -14,6 +14,112 @@ struct TranslationLayerCallbacks
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // A pool of objects that are recycled on specific fence values
+// with a maximum depth before blocking on RetrieveFromPool
+// This class assumes single threaded caller
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template<typename TResourceType>
+class CBoundedFencePool
+{
+public:
+    void ReturnToPool(TResourceType&& Resource, UINT64 FenceValue) noexcept
+    {
+        try
+        {
+            auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
+            m_Pool.emplace_back(FenceValue, std::move(Resource)); // throw( bad_alloc )
+        }
+        catch (std::bad_alloc&)
+        {
+            // Just drop the error
+            // All uses of this pool use unique_comptr, which will release the resource
+        }
+    }
+
+    template <typename PFNWaitForFenceValue, typename PFNCreateNew, typename... CreationArgType>
+    TResourceType RetrieveFromPool(UINT64 CurrentFenceValue, PFNWaitForFenceValue pfnWaitForFenceValue, PFNCreateNew pfnCreateNew, const CreationArgType&... CreationArgs) noexcept(false)
+    {
+        auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
+        TPool::iterator Head = m_Pool.begin();
+
+        if (Head == m_Pool.end())
+        {
+            return std::move(pfnCreateNew(CreationArgs...)); // throw( _com_error )
+        }
+        else if (CurrentFenceValue < Head->first)
+        {
+            if (m_Pool.size() < m_MaxInFlightDepth)
+            {
+                return std::move(pfnCreateNew(CreationArgs...)); // throw( _com_error )
+            }
+            else
+            {
+                pfnWaitForFenceValue(Head->first); // throw( _com_error )
+            }
+        }
+
+        assert(Head->second);
+        TResourceType ret = std::move(Head->second);
+        m_Pool.erase(Head);
+        return std::move(ret);
+    }
+
+    void Trim(UINT64 TrimThreshold, UINT64 CurrentFenceValue)
+    {
+        auto lock = m_pLock ? std::unique_lock(*m_pLock) : std::unique_lock<std::mutex>();
+
+        TPool::iterator Head = m_Pool.begin();
+
+        if (Head == m_Pool.end() || (CurrentFenceValue < Head->first))
+        {
+            return;
+        }
+
+        UINT64 difference = CurrentFenceValue - Head->first;
+
+        if (difference >= TrimThreshold)
+        {
+            // only erase one item per 'pump'
+            assert(Head->second);
+            m_Pool.erase(Head);
+        }
+    }
+
+    CBoundedFencePool(bool bLock = false, UINT MaxInFlightDepth = cDefaultMaxInFlightDepth) noexcept
+        : m_pLock(bLock ? new std::mutex : nullptr),
+        m_MaxInFlightDepth(MaxInFlightDepth)
+    {
+    }
+    CBoundedFencePool(CBoundedFencePool&& other) noexcept
+    {
+        m_Pool = std::move(other.m_Pool);
+        m_pLock = std::move(other.m_pLock);
+        m_MaxInFlightDepth = other.m_MaxInFlightDepth;
+    }
+    CBoundedFencePool& operator=(CBoundedFencePool&& other) noexcept
+    {
+        m_Pool = std::move(other.m_Pool);
+        m_pLock = std::move(other.m_pLock);
+        m_MaxInFlightDepth = other.m_MaxInFlightDepth;
+        return *this;
+    }
+
+    static constexpr UINT cDefaultMaxInFlightDepth = 1024;
+
+protected:
+    typedef std::pair<UINT64, TResourceType> TPoolEntry;
+    typedef std::list<TPoolEntry> TPool;
+
+    CBoundedFencePool(CBoundedFencePool const& other) = delete;
+    CBoundedFencePool& operator=(CBoundedFencePool const& other) = delete;
+
+protected:
+    TPool m_Pool;
+    std::unique_ptr<std::mutex> m_pLock;
+    UINT m_MaxInFlightDepth;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// A pool of objects that are recycled on specific fence values
 // This class assumes single threaded caller
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename TResourceType>

--- a/src/CommandListManager.cpp
+++ b/src/CommandListManager.cpp
@@ -26,7 +26,7 @@ namespace D3D12TranslationLayer
         , m_bNeedSubmitFence(false)
         , m_pCommandList(nullptr)
         , m_pCommandAllocator(nullptr)
-        , m_AllocatorPool(false /*bLock*/, cMaxInFlightDepth[(size_t)type]/* max allocators in use until wait/block for completion*/)
+        , m_AllocatorPool(false /*bLock*/, GetMaxInFlightDepth(type))
         , m_hWaitEvent(CreateEvent(nullptr, FALSE, FALSE, nullptr)) // throw( _com_error )
         , m_MaxAllocatedUploadHeapSpacePerCommandList(cMaxAllocatedUploadHeapSpacePerCommandList)
     {


### PR DESCRIPTION
CommandListManager/ImmediateContext: Create CBoundedFencePool to allow for CPU blocking after N in-flight pending commands. Apply 16 limit to Video Decode cmdlists.

Fixes https://github.com/microsoft/D3D11On12/issues/40