### PR TITLE
Use a synchronization-only command queue (COMMAND_LIST_TYPE_NONE) for Signal()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(FetchContent)
 FetchContent_Declare(
     DirectX-Headers
     GIT_REPOSITORY https://github.com/Microsoft/DirectX-Headers.git
-    GIT_TAG 53d22f0256832f4a36117386355d54e2331127de
+    GIT_TAG v1.606.4
 )
 FetchContent_MakeAvailable(DirectX-Headers)
 

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -873,6 +873,7 @@ public:
     unique_comptr<ID3D12Device1> m_pDevice12_1;
     unique_comptr<ID3D12Device2> m_pDevice12_2; // TODO: Instead of adding more next time, replace
     unique_comptr<ID3D12CompatibilityDevice> m_pCompatDevice;
+    unique_comptr<ID3D12CommandQueue> m_pSyncOnlyQueue;
 private:
     std::unique_ptr<CommandListManager> m_CommandLists[(UINT)COMMAND_LIST_TYPE::MAX_VALID];
 


### PR DESCRIPTION
When supported by the D3D12 version we're using, we can create a sync-only queue, which can only have signals and waits on it and is lighter weight than any other queue type. On this queue, we can do waits for all of our internal fences to complete, followed by a signal for the caller's fence, which effectively allows us to broadcast the signal to only complete when all internal timelines reach the appropriate completion point.