### PR TITLE
Fix conditions for determining when we have to stop trying to wait for the GPU to evict more memory

### DIFF
--- a/src/Residency.cpp
+++ b/src/Residency.cpp
@@ -222,8 +222,12 @@ HRESULT ResidencyManager::ProcessPagingWork(UINT CommandListIndex, ResidencySet 
                     }
 
                     // If there is nothing to trim OR the only objects 'Resident' are the ones about to be used by this execute.
-                    if (pResidentHead == nullptr ||
-                        std::equal(WaitedFenceValues, std::end(WaitedFenceValues), LastSubmittedFenceValues))
+                    bool ForceResidency = pResidentHead == nullptr;
+                    for (UINT i = 0; i < (UINT)COMMAND_LIST_TYPE::MAX_VALID && !ForceResidency; ++i)
+                    {
+                        ForceResidency = pResidentHead->LastUsedFenceValues[i] > LastSubmittedFenceValues[i];
+                    }
+                    if (ForceResidency)
                     {
                         // Make resident the rest of the objects as there is nothing left to trim
                         UINT32 NumObjects = (UINT32)MakeResidentList.size() - ObjectsMadeResident;


### PR DESCRIPTION
Equal was wrong, a > check was needed. Otherwise, the WaitForCommandList tries to re-flush the command list that we're in the middle of flushing.