### PR TITLE
Check shader decls before binding SRV, CB, samplers

### DIFF
--- a/include/ImmediateContext.inl
+++ b/include/ImmediateContext.inl
@@ -265,15 +265,15 @@ inline bool CViewBoundState<TBindable, NumBindSlots>::IsDirty(TDeclVector const&
 
     if (m_ShaderData.size() < rootSignatureBucketSize)
     {
-        // Did we move to a larger bucket size? If so, fill the extra shader data to null (unknown) descriptors
+        // Did we move to a larger bucket size? If so, fill the extra shader data to null (unknown) resource dimension
         m_ShaderData.resize(rootSignatureBucketSize, c_AnyNull);
         bDirty = true;
     }
     else if (m_ShaderData.size() > rootSignatureBucketSize)
     {
-        //Did we move to a smaller bucket size? If so, shrink the shader data to fit
+        // Did we move to a smaller bucket size? If so, shrink the shader data to fit
+        // Don't need to mark as dirty since the root signature won't be able to address the stale descriptors
         m_ShaderData.resize(rootSignatureBucketSize);
-        bDirty = true;
     }
 
     if (!bDirty)

--- a/include/ResourceBinding.hpp
+++ b/include/ResourceBinding.hpp
@@ -254,7 +254,7 @@ namespace D3D12TranslationLayer
         }
 
         bool UpdateBinding(_In_range_(0, NumBindings - 1) UINT slot, _In_opt_ TBindable* pBindable, EShaderStage stage) noexcept;
-        bool IsDirty(TDeclVector const& New, bool bKnownDirty) noexcept;
+        bool IsDirty(TDeclVector const& New, UINT rootSignatureBucketSize, bool bKnownDirty) noexcept;
 
         NullType GetNullType(_In_range_(0, NumBindings - 1) UINT slot) const noexcept
         {
@@ -304,10 +304,10 @@ namespace D3D12TranslationLayer
 
         bool UpdateBinding(_In_range_(0, NumBindings - 1) UINT slot, _In_opt_ Resource* pBindable, EShaderStage stage) noexcept;
 
-        bool IsDirty(_In_range_(0, NumBindings) UINT New) noexcept
+        bool IsDirty(_In_range_(0, NumBindings) UINT rootSignatureBucketSize) noexcept
         {
-            bool bDirty = New > m_ShaderData || DirtyBitsUpTo(New);
-            m_ShaderData = New;
+            bool bDirty = rootSignatureBucketSize > m_ShaderData || DirtyBitsUpTo(rootSignatureBucketSize);
+            m_ShaderData = rootSignatureBucketSize;
 
             return bDirty;
         }
@@ -338,10 +338,10 @@ namespace D3D12TranslationLayer
         bool UpdateBinding(_In_range_(0, NumBindings - 1) UINT slot,
             _In_ Sampler* pBindable) noexcept;
 
-        bool IsDirty(_In_range_(0, NumBindings) UINT New) noexcept
+        bool IsDirty(_In_range_(0, NumBindings) UINT rootSignatureBucketSize) noexcept
         {
-            bool bDirty = New > m_ShaderData || DirtyBitsUpTo(m_ShaderData);
-            m_ShaderData = New;
+            bool bDirty = rootSignatureBucketSize > m_ShaderData || DirtyBitsUpTo(rootSignatureBucketSize);
+            m_ShaderData = rootSignatureBucketSize;
 
             return bDirty;
         }


### PR DESCRIPTION
The Apply*Helper()s didn't verify that the shader they were trying to bind resources to actually used that type of resource, so there were cases where we would try to bind invalid data to shaders that didn't reference it. This didn't cause issues in applications, but does log a breaking error in the debug layer.