### PR TITLE
Fix narrowing conversion in `{}`

### DIFF
--- a/include/BatchedContext.hpp
+++ b/include/BatchedContext.hpp
@@ -510,8 +510,8 @@ public:
 
     struct CreationArgs
     {
-        UINT CreatesAndDestroysAreMultithreaded : 1;
-        UINT SubmitBatchesToWorkerThread : 1;
+        bool CreatesAndDestroysAreMultithreaded : 1;
+        bool SubmitBatchesToWorkerThread : 1;
         BatchedContext* pParentContext;
     };
     struct Callbacks


### PR DESCRIPTION
We've (the compiler team) started enforcing that `{}` initialization can't do narrowing conversions in more places, which means that this code will be broken in a new version of the compiler; this is one method to fix this; the alternative is to compare with `0` in the initialization of a few structure members down-file.

Note that this _does not_ break ABI, due to the following pointer member.

old:

```
class D3D12TranslationLayer::BatchedContext::CreationArgs       size(16):
        +---
 0.     | CreatesAndDestroysAreMultithreaded (bitstart=0,nbits=1)
 0.     | SubmitBatchesToWorkerThread (bitstart=1,nbits=1)
        | <alignment member> (size=4)
 8      | pParentContext
        +---
```

new:

```
class D3D12TranslationLayer::BatchedContext::CreationArgs       size(16):
        +---
 0.     | CreatesAndDestroysAreMultithreaded (bitstart=0,nbits=1)
 0.     | SubmitBatchesToWorkerThread (bitstart=1,nbits=1)
        | <alignment member> (size=7)
 8      | pParentContext
        +---
```

It also works in 32-bit ABIs since the pointer member will have align 4 -- instead of a 7-byte/3-byte alignment member, you'll get a 3-byte/0-byte alignment member, but the size stays the same.