### PR TITLE
Fix Dirty Flag Issue in SetConstantBuffers

### DIFF
--- a/include/Shader.inl
+++ b/include/Shader.inl
@@ -70,11 +70,20 @@ namespace D3D12TranslationLayer
             UINT slot = i + StartSlot;
             Resource* pCB = ppCBs[i];
             CurrentStageState.m_CBs.UpdateBinding(slot, pCB, eShader);
-            // TODO: Track offsets for diffing purposes to conditionally set this bit
-            CurrentStageState.m_CBs.SetDirtyBit(slot);
 
-            CurrentStageState.m_uConstantBufferOffsets[slot] = pFirstConstant ? pFirstConstant[i] : 0;
-            CurrentStageState.m_uConstantBufferCounts[slot] = pNumConstants ? pNumConstants[i] : D3D10_REQ_CONSTANT_BUFFER_ELEMENT_COUNT;
+            UINT prevFirstConstant = CurrentStageState.m_uConstantBufferOffsets[slot];
+            UINT prevNumConstants = CurrentStageState.m_uConstantBufferCounts[slot];
+
+            UINT newFirstConstant = pFirstConstant ? pFirstConstant[i] : 0;
+            UINT newNumConstants = pNumConstants ? pNumConstants[i] : D3D10_REQ_CONSTANT_BUFFER_ELEMENT_COUNT;
+
+            if (prevFirstConstant != newFirstConstant || prevNumConstants != newNumConstants)
+            {
+                CurrentStageState.m_CBs.SetDirtyBit(slot);
+            }
+
+            CurrentStageState.m_uConstantBufferOffsets[slot] = newFirstConstant;
+            CurrentStageState.m_uConstantBufferCounts[slot] = newNumConstants;
         }
     }
 };


### PR DESCRIPTION
SetConstantBuffers() was previously setting the dirty flag unconditionally, even when the states aren't actually dirty, which likely caused PreDraw() to do lots of unnecessary work.

However, it still needs to set the flag if the offset to the buffer changes or if the number of constants change. If the buffer itself changes, UpdateBinding() will set the dirty flag.

I've tested the change on an RTX 3070 with a map in CS:GO, and the FPS increased by about around 35%.