### PR TITLE
Ensure pending signals are submitted when async polling query status

### DIFF
--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -1395,6 +1395,8 @@ public:
     bool HasCommands(COMMAND_LIST_TYPE type) noexcept;
     UINT GetCommandListTypeMaskForQuery(EQueryType query) noexcept;
 
+    void PrepForCommandQueueSync(UINT commandListTypeMask);
+
     RootSignature* CreateOrRetrieveRootSignature(RootSignatureDesc const& desc) noexcept(false);
 
 private:

--- a/src/BatchedContext.cpp
+++ b/src/BatchedContext.cpp
@@ -1408,7 +1408,7 @@ bool BatchedContext::SyncWithBatch(uint64_t& BatchID, bool DoNotFlush, TFunc&& G
             // Not checking thread idle bit as we're already under the lock.
             if (m_QueuedBatches.empty())
             {
-                m_ImmCtx.Flush(FlushMask);
+                m_ImmCtx.PrepForCommandQueueSync(FlushMask);
             }
             else
             {

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -1150,7 +1150,7 @@ bool TRANSLATION_API ImmediateContext::Flush(UINT commandListTypeMask)
 
     for (UINT i = 0; i < (UINT)COMMAND_LIST_TYPE::MAX_VALID; i++)
     {
-        if (commandListTypeMask & (1 << i) && m_CommandLists[i] && m_CommandLists[i]->HasCommands())
+        if ((commandListTypeMask & (1 << i)) && m_CommandLists[i] && m_CommandLists[i]->HasCommands())
         {
             m_CommandLists[i]->SubmitCommandList();
             bSubmitCommandList = true;
@@ -1161,6 +1161,20 @@ bool TRANSLATION_API ImmediateContext::Flush(UINT commandListTypeMask)
     // these are expected to be cleaned up on a per-flush basis
     PostSubmitNotification();
     return bSubmitCommandList;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------
+void ImmediateContext::PrepForCommandQueueSync(UINT commandListTypeMask)
+{
+    Flush(commandListTypeMask);
+    for (UINT i = 0; i < (UINT)COMMAND_LIST_TYPE::MAX_VALID; i++)
+    {
+        if ((commandListTypeMask & (1 << i)) && m_CommandLists[i])
+        {
+            assert(!m_CommandLists[i]->HasCommands());
+            m_CommandLists[i]->PrepForCommandQueueSync();
+        }
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I'm not entirely sure how this could happen, but I did see a hang occur due to a loop where an app was polling a query status, and we were trying to wait for a fence value that wasn't associated with a command list (i.e. no actual commands were recorded) but the fence hadn't been signaled yet, so the wait was never satisfied. I suppose an event query is has no commands associated with it, so this could happen there.