### PR TITLE
stop using the internal _Ty type of std::bitset

### DIFF
--- a/include/D3D12TranslationLayerDependencyIncludes.h
+++ b/include/D3D12TranslationLayerDependencyIncludes.h
@@ -49,6 +49,9 @@
 #include <atomic>
 #include <optional>
 #include <mutex>
+#include <bitset>
+#include <type_traits>
+#include <climits>
 using std::min;
 using std::max;
 

--- a/include/ImmediateContext.inl
+++ b/include/ImmediateContext.inl
@@ -166,7 +166,7 @@ inline bool CBoundState<TBindable, NumBindSlots>::DirtyBitsUpTo(_In_range_(0, Nu
     }
     else
     {
-        constexpr UINT NumBitsPerWord = sizeof(std::bitset<NumBindings>::_Ty) * 8;
+        constexpr UINT NumBitsPerWord = sizeof(::std::conditional_t<NumBindings <= sizeof(unsigned long) * CHAR_BIT, unsigned long, unsigned long long>) * 8;
         // First, check whole "words" for any bit being set.
         UINT NumWordsToCheck = NumBitsToCheck / NumBitsPerWord;
         for (UINT word = 0; word < NumWordsToCheck; ++word)


### PR DESCRIPTION
This fixes a build break that will happen when the STL from VS 17.8 reaches windows.