### PR TITLE
[TSA bugs] Fix narrow/wide type comparison in loop condition

### DIFF
--- a/include/ImmediateContext.inl
+++ b/include/ImmediateContext.inl
@@ -244,7 +244,7 @@ inline bool CViewBoundState<TBindable, NumBindSlots>::IsDirty(TDeclVector const&
     // Note: Even though there are vector resize ops here, they cannot throw,
     // since the backing memory for the vector was already allocated using reserve(NumBindSlots)
     bool bDirty = bKnownDirty;
-    for (UINT i = 0; i < New.size(); ++i)
+    for (size_t i = 0; i < New.size(); ++i)
     {
         if (i >= m_ShaderData.size())
         {
@@ -594,7 +594,7 @@ inline void ImmediateContext::PreDraw() noexcept(false)
     {
         if (pShader)
         {
-            for (UINT i = 0; i < pShader->m_UAVDecls.size(); ++i)
+            for (size_t i = 0; i < pShader->m_UAVDecls.size(); ++i)
             {
                 if (i >= m_UAVDeclScratch.size())
                 {

--- a/include/Util.hpp
+++ b/include/Util.hpp
@@ -424,7 +424,7 @@ namespace D3D12TranslationLayer
             // Leave uninitialized otherwise
             if constexpr (!std::is_trivially_constructible<T>::value)
             {
-                for (UINT i = 0; i < m_Size && i < InlineSize; ++i)
+                for (size_t i = 0; i < m_Size && i < InlineSize; ++i)
                 {
                     new (std::addressof(m_InlineArray[i])) T(std::forward<TConstructionArgs>(constructionArgs)...);
                 }

--- a/src/Residency.cpp
+++ b/src/Residency.cpp
@@ -182,7 +182,8 @@ HRESULT ResidencyManager::ProcessPagingWork(UINT CommandListIndex, ResidencySet 
 
                 if (AvailableSpace > 0)
                 {
-                    for (UINT32 i = MakeResidentIndex; i < MakeResidentList.size(); i++)
+                    assert(MakeResidentList.size() < MAXUINT32);
+                    for (UINT32 i = MakeResidentIndex; i < static_cast<UINT32>(MakeResidentList.size()); i++)
                     {
                         // If we try to make this object resident, will we go over budget?
                         if (BatchSize + MakeResidentList[i].pManagedObject->Size > UINT64(AvailableSpace))

--- a/src/ResourceState.cpp
+++ b/src/ResourceState.cpp
@@ -159,7 +159,8 @@ namespace D3D12TranslationLayer
             return GetCommandListTypeMask(0);
         }
         UINT TypeMask = 0;
-        for (UINT i = 0; i < m_spExclusiveState.size(); ++i)
+        assert(m_spExclusiveState.size() < MAXUINT);
+        for (UINT i = 0; i < static_cast<UINT>(m_spExclusiveState.size()); ++i)
         {
             TypeMask |= GetCommandListTypeMask(i);
         }

--- a/src/SharedResourceHelpers.cpp
+++ b/src/SharedResourceHelpers.cpp
@@ -58,7 +58,8 @@ namespace D3D12TranslationLayer
         // The KM handle for a shared resource is simply an index into this
         // vector, to allow the core layer to clean up an 11on12 resource the same way as an 11 resource
         UINT i = 0;
-        for (; i < m_OpenResourceMap.size(); ++i)
+        assert(m_OpenResourceMap.size() < MAXUINT);
+        for (; i < static_cast<UINT>(m_OpenResourceMap.size()); ++i)
         {
             if (m_OpenResourceMap[i] == nullptr)
             {

--- a/src/VideoDevice.cpp
+++ b/src/VideoDevice.cpp
@@ -90,7 +90,7 @@ namespace D3D12TranslationLayer
     _Use_decl_annotations_
     void VideoDevice::GetVideoDecoderFormatCount(const GUID *pDecodeProfile, UINT *pFormatCount)
     {
-        for (DWORD i = 0; i < m_decodeProfiles.size(); i++)
+        for (size_t i = 0; i < m_decodeProfiles.size(); i++)
         {
             if (m_decodeProfiles[i].profileGUID == *pDecodeProfile)
             {
@@ -105,7 +105,7 @@ namespace D3D12TranslationLayer
     _Use_decl_annotations_
     void VideoDevice::GetVideoDecoderFormat(const GUID *pDecodeProfile, UINT Index, DXGI_FORMAT *pFormat)
     {
-        for (DWORD i = 0; i < m_decodeProfiles.size(); i++)
+        for (size_t i = 0; i < m_decodeProfiles.size(); i++)
         {
             if (m_decodeProfiles[i].profileGUID == *pDecodeProfile)
             {
@@ -126,11 +126,11 @@ namespace D3D12TranslationLayer
             ThrowFailure(E_POINTER);
         }
         *pSupported = FALSE;
-        for (DWORD i = 0; i < m_decodeProfiles.size(); i++)
+        for (size_t i = 0; i < m_decodeProfiles.size(); i++)
         {
             if (m_decodeProfiles[i].profileGUID == *pDecodeProfile)
             {
-                for (DWORD j = 0; j < m_decodeProfiles[i].formats.size(); j++)
+                for (size_t j = 0; j < m_decodeProfiles[i].formats.size(); j++)
                 {
                     if (format == m_decodeProfiles[i].formats[j] &&
                         CD3D11FormatHelper::GetTypeLevel(format) == D3D11FTL_FULL_TYPE)
@@ -147,7 +147,7 @@ namespace D3D12TranslationLayer
     //----------------------------------------------------------------------------------------------------------------------------------
     bool VideoDevice::IsProfileSupported(REFGUID DecodeProfile) noexcept
     {
-        for (DWORD i = 0; i < m_decodeProfiles.size(); i++)
+        for (size_t i = 0; i < m_decodeProfiles.size(); i++)
         {
             if (m_decodeProfiles[i].profileGUID == DecodeProfile)
             {
@@ -185,7 +185,7 @@ namespace D3D12TranslationLayer
     _Use_decl_annotations_
     void VideoDevice::GetVideoDecoderConfigCount(const VIDEO_DECODE_DESC *pDesc, UINT *pConfigCount)
     {
-        for (DWORD i = 0; i < m_decodeProfiles.size(); i++)
+        for (size_t i = 0; i < m_decodeProfiles.size(); i++)
         {
             if (m_decodeProfiles[i].profileGUID == pDesc->DecodeProfile)
             {
@@ -200,7 +200,7 @@ namespace D3D12TranslationLayer
     _Use_decl_annotations_
     void VideoDevice::GetVideoDecoderConfig(const VIDEO_DECODE_DESC *pDesc, UINT Index, VIDEO_DECODE_CONFIG *pConfig)
     {
-        for (DWORD i = 0; i < m_decodeProfiles.size(); i++)
+        for (size_t i = 0; i < m_decodeProfiles.size(); i++)
         {
             if (m_decodeProfiles[i].profileGUID == pDesc->DecodeProfile)
             {

--- a/src/VideoReferenceDataManager.cpp
+++ b/src/VideoReferenceDataManager.cpp
@@ -45,7 +45,8 @@ namespace D3D12TranslationLayer
     UINT16 ReferenceDataManager::FindRemappedIndex(UINT16 originalIndex)
     {
         // Check if the index is already mapped.
-        for (UINT16 remappedIndex = 0; remappedIndex < referenceDatas.size(); remappedIndex++)
+        assert(referenceDatas.size() < MAXUINT16);
+        for (UINT16 remappedIndex = 0; remappedIndex < static_cast<UINT16>(referenceDatas.size()); remappedIndex++)
         {
             if (referenceDatas[remappedIndex].originalIndex == originalIndex)
             {


### PR DESCRIPTION
Generally tried to just change counting variables to size_t to match the comparison.
In cases where the counting variable was assigned in to other narrower types I just did an assert on the size of the comparison value and then static_cast it to match.

Realistically shouldn't hit these situations anyway.