### PR TITLE
Fix lockable shared buffers

### DIFF
--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -48,7 +48,7 @@ namespace D3D12TranslationLayer
         bool& ownsResource = m_Identity->m_bOwnsUnderlyingResource;
         ownsResource = (m_creationArgs.m_heapDesc.Properties.Type == D3D12_HEAP_TYPE_DEFAULT ||
             m_creationArgs.m_heapDesc.Properties.Type == D3D12_HEAP_TYPE_CUSTOM ||
-            OwnsReadbackHeap() ||
+            OwnsReadbackHeap() || IsLockableSharedBuffer() ||
             (AppDesc()->Usage() == RESOURCE_USAGE_DYNAMIC && (Parent()->ResourceDimension12() != D3D12_RESOURCE_DIMENSION_BUFFER)));
 
         // Create/retrieve the resource


### PR DESCRIPTION
When 9on12 doesn't translate lockable shared buffers to `HEAP_TYPE_DEFAULT` (i.e. UMA), we go down the wrong path, and map/unmap doesn't actually get contents into the shared buffer anymore. This is a simple fix to redirect that.