### PR TITLE
[TSA] fix Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/Residency.cpp
+++ b/src/Residency.cpp
@@ -234,7 +234,7 @@ HRESULT ResidencyManager::ProcessPagingWork(UINT CommandListIndex, ResidencySet 
                         UINT32 NumObjects = (UINT32)MakeResidentList.size() - ObjectsMadeResident;
 
                         // Gather up the remaining underlying objects
-                        for (UINT32 i = MakeResidentIndex; i < MakeResidentList.size(); i++)
+                        for (size_t i = MakeResidentIndex; i < MakeResidentList.size(); i++)
                         {
                             MakeResidentList[i].pUnderlying = MakeResidentList[i].pManagedObject->pUnderlying;
                         }

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -1011,7 +1011,7 @@ namespace D3D12TranslationLayer
     bool Resource::WaitForOutstandingResourcesIfNeeded(bool DoNotWait)
     {
         while (m_Identity &&
-               m_Identity->m_OutstandingResources.size() >= m_Identity->m_MaxOutstandingResources)
+               m_Identity->m_OutstandingResources.size() >= (size_t)m_Identity->m_MaxOutstandingResources)
         {
             auto outstandingResourceUse = m_Identity->m_OutstandingResources.front();
 


### PR DESCRIPTION
The case in Resource.cpp shouldn't ever be able to cause the infinite loop that CodeQL is concerned about since we are removing entries from the list (the size there is the source of the wider type)