### PR TITLE
Swallow failures in ~VideoProcess()

### DIFF
--- a/src/VideoProcess.cpp
+++ b/src/VideoProcess.cpp
@@ -38,7 +38,19 @@ namespace D3D12TranslationLayer
     //----------------------------------------------------------------------------------------------------------------------------------
     VideoProcess::~VideoProcess() noexcept
     {
-        m_pParent->Flush(COMMAND_LIST_TYPE_VIDEO_PROCESS_MASK);
+        // Stop exception here, as destructor is noexcept
+        try
+        {
+            m_pParent->Flush(COMMAND_LIST_TYPE_VIDEO_PROCESS_MASK); //throws
+        }
+        catch (_com_error&)
+        {
+            // success = false;
+        }
+        catch (std::bad_alloc&)
+        {
+            // success = false;
+        }
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is similar to the pattern in ~VideoDecode to handle failures in flushing the commandlist in a destructor.