### PR TITLE
Fix compilation under /permissive- and C++20

### DIFF
--- a/include/BlockAllocators.h
+++ b/include/BlockAllocators.h
@@ -69,7 +69,7 @@ template<class _BlockType, class _SizeType = SIZE_T>
 class CNullBlockAllocator
 {
 public:
-    _BlockType Allocate(_SizeType size) { return _BlockType; /* Returns a default block*/ }
+    _BlockType Allocate(_SizeType size) { return {}; /* Returns a default block*/ }
     void Deallocate(_BlockType &block) { assert(block.GetSize() == 0); }
     bool IsOwner(_BlockType &block) const { return block.GetSize() == 0 && block.GetOffset() == 0; }
     void Reset() {}
@@ -105,7 +105,7 @@ public:
     // Required Allocator functions
     _BlockType Allocate(_SizeType size);
     void Deallocate(const _BlockType &block);
-    bool IsOwner(const _BlockType &block) const { return block.GetSize() == blockSize; }
+    bool IsOwner(const _BlockType &block) const { return block.GetSize() == m_blockSize; }
     void Reset();
 };
 

--- a/include/DeviceChild.hpp
+++ b/include/DeviceChild.hpp
@@ -64,7 +64,7 @@ namespace D3D12TranslationLayer
         template <typename TIface>
         void AddToDeferredDeletionQueue(unique_comptr<TIface>& spObject, COMMAND_LIST_TYPE CommandListType)
         {
-            AddToDeferredDeletionQueue(spObject, CommandListType, m_pParent->GetCommandListID(CommandListType));
+            AddToDeferredDeletionQueue(spObject, CommandListType, GetCommandListID(CommandListType));
         }
 
         void SwapIdentities(DeviceChild& Other)
@@ -78,6 +78,7 @@ namespace D3D12TranslationLayer
         }
 
         void AddToDeferredDeletionQueue(ID3D12Object* pObject);
+        UINT64 GetCommandListID(COMMAND_LIST_TYPE CommandListType) noexcept;
     };
 
     template <typename TIface>
@@ -100,7 +101,7 @@ namespace D3D12TranslationLayer
         }
         TIface* GetForUse(COMMAND_LIST_TYPE CommandListType)
         {
-            return GetForUse(CommandListType, m_pParent->GetCommandListID(CommandListType));
+            return GetForUse(CommandListType, GetCommandListID(CommandListType));
         }
         TIface* GetForImmediateUse() { return m_spIface.get(); }
 

--- a/include/ImmediateContext.inl
+++ b/include/ImmediateContext.inl
@@ -278,7 +278,7 @@ inline bool CViewBoundState<TBindable, NumBindSlots>::IsDirty(TDeclVector const&
 
     if (!bDirty)
     {
-        bDirty = DirtyBitsUpTo(static_cast<UINT>(rootSignatureBucketSize));
+        bDirty = this->DirtyBitsUpTo(static_cast<UINT>(rootSignatureBucketSize));
     }
 
     return bDirty;
@@ -954,6 +954,23 @@ inline void GetBufferViewDesc(Resource* pBuffer, TDesc& Desc, UINT APIOffset, UI
     }
 }
 
+//----------------------------------------------------------------------------------------------------------------------------------
+template<EShaderStage eShader> struct DescriptorBindFuncs
+{
+    static decltype(&ID3D12GraphicsCommandList::SetGraphicsRootDescriptorTable) GetBindFunc()
+    {
+        return &ID3D12GraphicsCommandList::SetGraphicsRootDescriptorTable;
+    }
+};
+template<> struct DescriptorBindFuncs<e_CS>
+{
+    static decltype(&ID3D12GraphicsCommandList::SetComputeRootDescriptorTable) GetBindFunc()
+    {
+        return &ID3D12GraphicsCommandList::SetComputeRootDescriptorTable;
+    }
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------
 template<EShaderStage eShader> struct SRVBindIndices;
 template<> struct SRVBindIndices<e_PS> { static const UINT c_TableIndex = 1; };
 template<> struct SRVBindIndices<e_VS> { static const UINT c_TableIndex = 4; };
@@ -1024,22 +1041,6 @@ inline void ImmediateContext::ApplySamplersHelper() noexcept
         SamplerBindIndices<eShader>::c_TableIndex,
         CurrentState.m_SamplerTableBase);
 }
-
-//----------------------------------------------------------------------------------------------------------------------------------
-template<EShaderStage eShader> struct DescriptorBindFuncs
-{
-    static decltype(&ID3D12GraphicsCommandList::SetGraphicsRootDescriptorTable) GetBindFunc()
-    {
-        return &ID3D12GraphicsCommandList::SetGraphicsRootDescriptorTable;
-    }
-};
-template<> struct DescriptorBindFuncs<e_CS>
-{
-    static decltype(&ID3D12GraphicsCommandList::SetComputeRootDescriptorTable) GetBindFunc()
-    {
-        return &ID3D12GraphicsCommandList::SetComputeRootDescriptorTable;
-    }
-};
 
 //----------------------------------------------------------------------------------------------------------------------------------
 inline void TRANSLATION_API ImmediateContext::Dispatch(UINT x, UINT y, UINT z)

--- a/include/ResourceBinding.hpp
+++ b/include/ResourceBinding.hpp
@@ -250,7 +250,7 @@ namespace D3D12TranslationLayer
         CViewBoundState() noexcept(false)
             : CBoundState<TBindable, NumBindSlots>()
         {
-            m_ShaderData.reserve(NumBindings); // throw( bad_alloc )
+            m_ShaderData.reserve(this->NumBindings); // throw( bad_alloc )
         }
 
         bool UpdateBinding(_In_range_(0, NumBindings - 1) UINT slot, _In_opt_ TBindable* pBindable, EShaderStage stage) noexcept;

--- a/include/View.hpp
+++ b/include/View.hpp
@@ -125,7 +125,7 @@ namespace D3D12TranslationLayer
 
         const TDesc12& GetDesc12() noexcept;
 
-        bool IsUpToDate() const noexcept { return m_pResource->GetUniqueness<TIface>() == m_ViewUniqueness; }
+        bool IsUpToDate() const noexcept;
         HRESULT RefreshUnderlying() noexcept;
         D3D12_CPU_DESCRIPTOR_HANDLE GetRefreshedDescriptorHandle()
         {

--- a/include/View.inl
+++ b/include/View.inl
@@ -89,7 +89,7 @@ namespace D3D12TranslationLayer
         __if_exists(TDesc12::Buffer)
         {
             typedef decltype(TDesc12::Buffer) TBufferDesc12;
-            if (m_pResource->AppDesc()->ResourceDimension() == D3D11_RESOURCE_DIMENSION_BUFFER)
+            if (m_pResource->AppDesc()->ResourceDimension() == static_cast<int>(D3D11_RESOURCE_DIMENSION_BUFFER))
             {
                 UINT Divisor = GetByteAlignment(m_Desc.Format);
                 __if_exists(TBufferDesc12::StructureByteStride)

--- a/include/View.inl
+++ b/include/View.inl
@@ -109,6 +109,13 @@ namespace D3D12TranslationLayer
 
     //----------------------------------------------------------------------------------------------------------------------------------
     template<typename TIface>
+    bool View<TIface>::IsUpToDate() const noexcept
+    {
+        return m_pResource->GetUniqueness<TIface>() == m_ViewUniqueness;
+    }
+
+    //----------------------------------------------------------------------------------------------------------------------------------
+    template<typename TIface>
     HRESULT View<TIface>::RefreshUnderlying() noexcept
     {
         if (m_ViewUniqueness != m_pResource->GetUniqueness<TIface>())

--- a/include/segmented_stack.h
+++ b/include/segmented_stack.h
@@ -104,9 +104,9 @@ inline segmented_stack< T, segment_size, unary >::segmented_stack(const unary& n
 template< class T, size_t segment_size, typename unary >
 inline void segmented_stack< T, segment_size, unary >::free()
 {
-    for (segment_vector::iterator segment = m_segments.begin(); segment != m_segments.end(); ++segment)
+    for (auto segment = m_segments.begin(); segment != m_segments.end(); ++segment)
     {
-        for (segment_range::iterator it = segment->m_begin; it != segment->m_end; ++it)
+        for (auto it = segment->m_begin; it != segment->m_end; ++it)
         {
             it->~T();
         }
@@ -324,9 +324,9 @@ inline void segmented_stack< T, segment_size, unary >::swap(segmented_stack< T, 
 template< class T, size_t segment_size, typename unary >
 inline void segmented_stack< T, segment_size, unary >::clear()
 {
-    for (segment_vector::iterator segment = m_segments.begin(); segment != m_segments.end(); ++segment)
+    for (auto segment = m_segments.begin(); segment != m_segments.end(); ++segment)
     {
-        for (segment_range::iterator it = segment->m_begin; it != segment->m_end; ++it)
+        for (auto it = segment->m_begin; it != segment->m_end; ++it)
         {
             it->~T();
         }

--- a/src/BlitHelper.cpp
+++ b/src/BlitHelper.cpp
@@ -353,7 +353,8 @@ namespace D3D12TranslationLayer
         D3D12_GPU_DESCRIPTOR_HANDLE SRVBaseGPU = m_pParent->m_ViewHeap.GPUHandle(SRVBaseSlot);
         pCommandList->SetGraphicsRootDescriptorTable(0, SRVBaseGPU);
 
-        pCommandList->OMSetRenderTargets(1, &pRTV->GetRefreshedDescriptorHandle(), TRUE, nullptr);
+        auto Descriptor = pRTV->GetRefreshedDescriptorHandle();
+        pCommandList->OMSetRenderTargets(1, &Descriptor, TRUE, nullptr);
 
         // Constant buffers: srcRect, src dimensions
         {

--- a/src/DeviceChild.cpp
+++ b/src/DeviceChild.cpp
@@ -9,6 +9,11 @@ namespace D3D12TranslationLayer
         m_pParent->AddObjectToDeferredDeletionQueue(pObject, m_LastUsedCommandListID, m_bWaitForCompletionRequired);
     }
 
+    UINT64 DeviceChild::GetCommandListID(COMMAND_LIST_TYPE CommandListType) noexcept
+    {
+        return m_pParent->GetCommandListID(CommandListType);
+    }
+
     void BatchedDeviceChild::ProcessBatch()
     {
         m_Parent.ProcessBatch();

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -109,7 +109,7 @@ namespace D3D12TranslationLayer
     {
         assert(createArgs.m_FormatEmulation == FormatEmulation::YV12 || createArgs.m_FormatEmulation == FormatEmulation::None);
         if (   createArgs.m_appDesc.Usage() == RESOURCE_USAGE_STAGING
-            || createArgs.m_appDesc.Usage() == D3D11_USAGE_DYNAMIC)
+            || createArgs.m_appDesc.Usage() == static_cast<int>(D3D11_USAGE_DYNAMIC))
         {
             if (GetSubresourceMultiplier(createArgs) > 1)
             {
@@ -123,7 +123,7 @@ namespace D3D12TranslationLayer
     inline UINT GetSubresourcesForFormatEmulationStagingData(ResourceCreationArgs const& createArgs) noexcept
     {
         return (   (   createArgs.m_appDesc.Usage() == RESOURCE_USAGE_STAGING 
-                    || createArgs.m_appDesc.Usage() == D3D11_USAGE_DYNAMIC)
+                    || createArgs.m_appDesc.Usage() == static_cast<int>(D3D11_USAGE_DYNAMIC))
                 && (   GetSubresourceMultiplier(createArgs) > 1
                     || createArgs.m_FormatEmulation != FormatEmulation::None)) ?
             GetTotalSubresources(createArgs) : 0u;
@@ -138,7 +138,7 @@ namespace D3D12TranslationLayer
 
     inline UINT GetSubresourcesForDynamicTexturePlaneData(ResourceCreationArgs const& createArgs) noexcept
     {
-        return (createArgs.m_appDesc.Usage() == D3D11_USAGE_DYNAMIC) ?
+        return (createArgs.m_appDesc.Usage() == static_cast<int>(D3D11_USAGE_DYNAMIC)) ?
             createArgs.m_appDesc.Subresources() / createArgs.m_appDesc.NonOpaquePlaneCount() : 0u;
     }
 
@@ -154,8 +154,8 @@ namespace D3D12TranslationLayer
         // We should refactor so that the desc doesn't change after construction...
         return ((createArgs.m_desc12.Flags & D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS) != D3D12_RESOURCE_FLAG_NONE ||
                 createArgs.m_desc12.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER) &&
-                (createArgs.m_appDesc.Usage() == D3D11_USAGE_DEFAULT ||
-                 createArgs.m_appDesc.Usage() == D3D11_USAGE_IMMUTABLE);
+                (createArgs.m_appDesc.Usage() == static_cast<int>(D3D11_USAGE_DEFAULT) ||
+                 createArgs.m_appDesc.Usage() == static_cast<int>(D3D11_USAGE_IMMUTABLE));
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------
@@ -198,7 +198,7 @@ namespace D3D12TranslationLayer
 
         // Default row-major textures are unsupported by D3D12 (except for cross-adapter), therefore
         // they are emulated using buffers and should typically be handled similarly to staging textures.
-        if (m_effectiveUsage == D3D11_USAGE_DEFAULT &&
+        if (m_effectiveUsage == static_cast<int>(D3D11_USAGE_DEFAULT) &&
             Parent()->ResourceDimension12() != D3D12_RESOURCE_DIMENSION_BUFFER &&
             Parent()->ApiTextureLayout12() == D3D12_TEXTURE_LAYOUT_ROW_MAJOR)
         {

--- a/src/SubresourceHelpers.cpp
+++ b/src/SubresourceHelpers.cpp
@@ -794,8 +794,8 @@ namespace D3D12TranslationLayer
             if (DSMode != ReadOrWrite)
             {
                 bool bWritable = DSMode == WriteOnly;
-                bool bDepth = !(Desc.Flags & D3D11_DSV_READ_ONLY_DEPTH) == bWritable;
-                bool bStencil = !(Desc.Flags & D3D11_DSV_READ_ONLY_STENCIL) == bWritable;
+                bool bDepth = !(Desc.Flags & static_cast<int>(D3D11_DSV_READ_ONLY_DEPTH)) == bWritable;
+                bool bStencil = !(Desc.Flags & static_cast<int>(D3D11_DSV_READ_ONLY_STENCIL)) == bWritable;
                 m_BeginPlane = (bDepth ? 0 : 1);
                 m_EndPlane = (bStencil ? 2 : 1);
             }

--- a/src/VideoDecodeStatistics.cpp
+++ b/src/VideoDecodeStatistics.cpp
@@ -153,7 +153,8 @@ namespace D3D12TranslationLayer
         CD3DX12_RANGE ReadRange(0, GetResultOffsetForIndex(m_ResultCount));
         ThrowFailure(m_ResultBuffer.Map(0, &ReadRange, &pMappedData));
 
-        auto Unmap = MakeScopeExit([&]() { m_ResultBuffer.Unmap(0, &CD3DX12_RANGE(0,0)); });
+        auto Range = CD3DX12_RANGE(0, 0);
+        auto Unmap = MakeScopeExit([&]() { m_ResultBuffer.Unmap(0, &Range); });
 
         // Determine the fence ID of the last completed 
         UINT64 lastCompletedFenceID = m_pParent->GetCompletedFenceValue(COMMAND_LIST_TYPE::VIDEO_DECODE);

--- a/src/VideoProcess.cpp
+++ b/src/VideoProcess.cpp
@@ -713,7 +713,8 @@ namespace D3D12TranslationLayer
                 pCommandList->RSSetViewports(1, &Viewport);
                 pCommandList->RSSetScissorRects(1, &Scissor);
 
-                pCommandList->OMSetRenderTargets(1, &outputRTV.GetRefreshedDescriptorHandle(), TRUE, nullptr);
+                auto Descriptor = outputRTV.GetRefreshedDescriptorHandle();
+                pCommandList->OMSetRenderTargets(1, &Descriptor, TRUE, nullptr);
                 pCommandList->SetGraphicsRootDescriptorTable(1, SRVBaseGPU);
 
                 pCommandList->DrawInstanced(4, 1, 0, 0);


### PR DESCRIPTION
This PR fixes compilation of D3D12TranslationLayer under `/permissive-` and C++20. It expands upon the conformance fixes from https://github.com/microsoft/D3D12TranslationLayer/pull/28 but does not attempt to resolve the circular dependency issue (this may be worth considering for a followup PR.)