### PR TITLE
Don't call SetEventOnCompletion for an already-completed fence value

### DIFF
--- a/src/CommandListManager.cpp
+++ b/src/CommandListManager.cpp
@@ -451,7 +451,14 @@ namespace D3D12TranslationLayer
         }
 #endif
 
-        return m_Fence.SetEventOnCompletion(FenceValue, hEvent);
+        if (m_Fence.GetCompletedValue() >= FenceValue)
+        {
+            return SetEvent(hEvent) ? S_OK : E_FAIL;
+        }
+        else
+        {
+            return m_Fence.SetEventOnCompletion(FenceValue, hEvent);
+        }
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A new D3D12 warning will fire when calling `SetEventOnCompletion` for fence value 0, which is always completed. Let's not do that.