### PR TITLE
Make use of UnrestrictedBufferTextureCopyPitchSupported

### DIFF
--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -1722,9 +1722,12 @@ public: // cached feature data
         };
     }const m_architecture;
 
+	const D3D12_FEATURE_DATA_D3D12_OPTIONS13& GetOptions13() const { return m_options13; }
+
 private: // helper methods to initialize feature data
 
     ArchitectureFlags QueryArchitectureFlags();
+    D3D12_FEATURE_DATA_D3D12_OPTIONS13 m_options13;
 };
 
 DEFINE_ENUM_FLAG_OPERATORS(ImmediateContext::UpdateSubresourcesFlags);

--- a/include/ImmediateContext.hpp
+++ b/include/ImmediateContext.hpp
@@ -1076,7 +1076,7 @@ public:
         void AssertPreconditions(const D3D11_SUBRESOURCE_DATA* pSrcData, const void* pClearPattern);
 #endif
 
-        bool InitializePlacementsAndCalculateSize(const D3D12_BOX* pDstBox, ID3D12Device* pDevice);
+        bool InitializePlacementsAndCalculateSize(const D3D12_BOX* pDstBox, ImmediateContext& ImmCtx);
         bool NeedToRespectPredication(UpdateSubresourcesFlags flags) const;
         bool NeedTemporaryUploadHeap(UpdateSubresourcesFlags flags, ImmediateContext& ImmCtx) const;
         void InitializeMappableResource(UpdateSubresourcesFlags flags, ImmediateContext& ImmCtx, D3D12_BOX const* pDstBox);

--- a/include/Resource.hpp
+++ b/include/Resource.hpp
@@ -444,7 +444,7 @@ namespace D3D12TranslationLayer
         UINT64 GetResourceSize() noexcept;
         static D3D12_HEAP_TYPE GetD3D12HeapType(RESOURCE_USAGE usage, UINT cpuAccessFlags) noexcept;
 
-        static void FillSubresourceDesc(ID3D12Device* pDevice, DXGI_FORMAT, UINT Width, UINT Height, UINT Depth, _Out_ D3D12_PLACED_SUBRESOURCE_FOOTPRINT& Placement) noexcept;
+        static void FillSubresourceDesc(ID3D12Device* pDevice, bool supportsUnrestrictedBufferTextureCopyPitch, DXGI_FORMAT, UINT Width, UINT Height, UINT Depth, _Out_ D3D12_PLACED_SUBRESOURCE_FOOTPRINT& Placement) noexcept;
         UINT DepthPitch(UINT Subresource) noexcept;
 
         template<typename TViewIface> UINT GetUniqueness() const noexcept { return m_AllUniqueness; }

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -187,6 +187,10 @@ ImmediateContext::ImmediateContext(UINT nodeIndex, D3D12_FEATURE_DATA_D3D12_OPTI
     m_SamplerHeap.m_Desc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
     m_SamplerHeap.m_Desc.NodeMask = GetNodeMask();
 
+    //Fetch additional caps
+    m_options13 = {};
+    pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS13, &m_options13, sizeof(m_options13));
+
     // Create initial objects
     hr = m_pDevice12->CreateDescriptorHeap(&m_ViewHeap.m_Desc, IID_PPV_ARGS(&m_ViewHeap.m_pDescriptorHeap));
     ThrowFailure(hr); //throw( _com_error )

--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -2970,7 +2970,7 @@ ImmediateContext::CPrepareUpdateSubresourcesHelper::CPrepareUpdateSubresourcesHe
 #if DBG
     AssertPreconditions(pSrcData, pClearPattern);
 #endif
-    bool bEmptyBox = InitializePlacementsAndCalculateSize(pDstBox, ImmCtx.m_pDevice12.get());
+    bool bEmptyBox = InitializePlacementsAndCalculateSize(pDstBox, ImmCtx);
     if (bEmptyBox)
     {
         return;
@@ -3006,7 +3006,7 @@ void ImmediateContext::CPrepareUpdateSubresourcesHelper::AssertPreconditions(con
 #endif
 
 //----------------------------------------------------------------------------------------------------------------------------------
-bool ImmediateContext::CPrepareUpdateSubresourcesHelper::InitializePlacementsAndCalculateSize(const D3D12_BOX* pDstBox, ID3D12Device* pDevice)
+bool ImmediateContext::CPrepareUpdateSubresourcesHelper::InitializePlacementsAndCalculateSize(const D3D12_BOX* pDstBox, ImmediateContext& ImmCtx)
 {
     auto& LocalPlacementDescs = PreparedStorage.LocalPlacementDescs;
 
@@ -3030,7 +3030,8 @@ bool ImmediateContext::CPrepareUpdateSubresourcesHelper::InitializePlacementsAnd
                 }
 
                 // Note: D3D11 provides a subsampled box, so for planar formats, we need to use the plane format to avoid subsampling again
-                Resource::FillSubresourceDesc(pDevice,
+                Resource::FillSubresourceDesc(ImmCtx.m_pDevice12.get(),
+                                                ImmCtx.GetOptions13().UnrestrictedBufferTextureCopyPitchSupported,
                                                 Dst.GetSubresourcePlacement(Subresource).Footprint.Format,
                                                 pDstBox->right - pDstBox->left,
                                                 pDstBox->bottom - pDstBox->top,

--- a/src/Resource.cpp
+++ b/src/Resource.cpp
@@ -705,6 +705,26 @@ namespace D3D12TranslationLayer
         ID3D12Device* pDevice = m_pParent->m_pDevice12.get();
 
         pDevice->GetCopyableFootprints(&ResDesc, 0, NumSubresources(), 0, &m_SubresourcePlacement[0], nullptr, nullptr, nullptr);
+
+        // If unrestricted pitch is supported, we can use tighter packing for non-planar resources
+        // instead of the default 256-byte alignment that GetCopyableFootprints applies
+        if (m_pParent->GetOptions13().UnrestrictedBufferTextureCopyPitchSupported && AppDesc()->NonOpaquePlaneCount() == 1)
+        {
+            UINT64 m_totalSize = 0;
+            for (UINT subresourceIndex = 0; subresourceIndex < NumSubresources(); subresourceIndex++)
+            {
+                auto& footprint = m_SubresourcePlacement[subresourceIndex];
+
+                UINT minPitch = 0;
+                CD3D11FormatHelper::CalculateMinimumRowMajorRowPitch(footprint.Footprint.Format, footprint.Footprint.Width, minPitch);
+                footprint.Footprint.RowPitch = minPitch;
+                footprint.Offset = m_totalSize;
+
+                UINT slicePitch = 0;
+                CD3D11FormatHelper::CalculateMinimumRowMajorSlicePitch(footprint.Footprint.Format, footprint.Footprint.RowPitch, footprint.Footprint.Height, slicePitch);
+                m_totalSize += slicePitch * footprint.Footprint.Depth;
+            }
+        }
         
         if (m_SubresourcePlacement[0].Footprint.RowPitch == -1)
         {
@@ -741,7 +761,7 @@ namespace D3D12TranslationLayer
                 }
             }
         }
-        else
+        else if(!m_pParent->GetOptions13().UnrestrictedBufferTextureCopyPitchSupported || AppDesc()->ResourceDimension() == D3D12_RESOURCE_DIMENSION_BUFFER)
         {
             // D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT is used to ensure that constant buffers are multiples of 256 bytes in size
             m_SubresourcePlacement[0].Footprint.RowPitch =
@@ -749,7 +769,7 @@ namespace D3D12TranslationLayer
         }
     }
 
-    void Resource::FillSubresourceDesc(ID3D12Device* pDevice, DXGI_FORMAT Format, UINT PlaneWidth, UINT PlaneHeight, UINT Depth, _Out_ D3D12_PLACED_SUBRESOURCE_FOOTPRINT& Placement) noexcept
+    void Resource::FillSubresourceDesc(ID3D12Device* pDevice, bool supportsUnrestrictedBufferTextureCopyPitch, DXGI_FORMAT Format, UINT PlaneWidth, UINT PlaneHeight, UINT Depth, _Out_ D3D12_PLACED_SUBRESOURCE_FOOTPRINT& Placement) noexcept
     {
         CD3DX12_RESOURCE_DESC ResourceDesc(
             D3D12_RESOURCE_DIMENSION_TEXTURE2D,
@@ -774,7 +794,10 @@ namespace D3D12TranslationLayer
         pDevice->GetCopyableFootprints(&ResourceDesc, 0, 1, 0, &Placement, nullptr, nullptr, nullptr);
 
         // D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT is used to ensure that constant buffers are multiples of 256 bytes in size
-        Placement.Footprint.RowPitch = Align<UINT>(Placement.Footprint.RowPitch, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        if (!supportsUnrestrictedBufferTextureCopyPitch || ResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER)
+        {
+            Placement.Footprint.RowPitch = Align<UINT>(Placement.Footprint.RowPitch, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+        }
     }
 
     //----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When Unrestricted Buffer Texture Copy Pitch is supported, we are able to ignore the aligned row pitch from GetCopyableFootprints and instead align based on bytes-per-element. This lets us take the fast path in data upload more often than not.

Disabled for planar resources since I noticed test failures when NV12 format is used.