### PR TITLE
[Clang] Fix expected a qualified name after 'typename' warning

### DIFF
--- a/include/Allocator.h
+++ b/include/Allocator.h
@@ -107,7 +107,7 @@ namespace D3D12TranslationLayer
     class ConditionalAllocator
     {
     public:
-        typedef bool(*RequiresDirectAllocationFunctionType)(typename _SizeType, typename AllocationArgs);
+        typedef bool(*RequiresDirectAllocationFunctionType)(_SizeType, AllocationArgs);
 
         template <typename... SuballocationAllocatorArgs, typename... DirectAllocatorArgs>
         ConditionalAllocator(std::tuple<SuballocationAllocatorArgs...> suballocatedAllocatorArgs,

--- a/include/View.hpp
+++ b/include/View.hpp
@@ -117,10 +117,10 @@ namespace D3D12TranslationLayer
         };
 
     public: // Methods
-        static View *CreateView(ImmediateContext* pDevice, const typename TDesc12 &Desc, Resource &ViewResource) noexcept(false) { return new View(pDevice, Desc, ViewResource); }
+        static View *CreateView(ImmediateContext* pDevice, const TDesc12 &Desc, Resource &ViewResource) noexcept(false) { return new View(pDevice, Desc, ViewResource); }
         static void DestroyView(View* pView) { delete pView; }
 
-        View(ImmediateContext* pDevice, const typename TDesc12 &Desc, Resource &ViewResource) noexcept(false);
+        View(ImmediateContext* pDevice, const TDesc12 &Desc, Resource &ViewResource) noexcept(false);
         ~View() noexcept;
 
         const TDesc12& GetDesc12() noexcept;

--- a/include/View.inl
+++ b/include/View.inl
@@ -188,7 +188,7 @@ namespace D3D12TranslationLayer
 
     //----------------------------------------------------------------------------------------------------------------------------------
     template<typename TIface>
-    View<TIface>::View(ImmediateContext* pDevice, const typename TDesc12 &Desc, Resource &ViewResource) noexcept(false)
+    View<TIface>::View(ImmediateContext* pDevice, const TDesc12 &Desc, Resource &ViewResource) noexcept(false)
         : ViewBase(pDevice,
         &ViewResource,
         CViewSubresourceSubset(Desc,
@@ -217,7 +217,7 @@ namespace D3D12TranslationLayer
     //----------------------------------------------------------------------------------------------------------------------------------
     // Specialized because no underlying D3D12 video views
     template<>
-    inline View<VideoDecoderOutputViewType>::View(ImmediateContext* pDevice, const typename TDesc12 &Desc, Resource &ViewResource) noexcept(false)
+    inline View<VideoDecoderOutputViewType>::View(ImmediateContext* pDevice, const TDesc12 &Desc, Resource &ViewResource) noexcept(false)
         : ViewBase(pDevice,
             &ViewResource,
             CViewSubresourceSubset(Desc,
@@ -237,7 +237,7 @@ namespace D3D12TranslationLayer
 
     //----------------------------------------------------------------------------------------------------------------------------------
     template<>
-    inline View<VideoProcessorInputViewType>::View(ImmediateContext* pDevice, const typename TDesc12 &Desc, Resource &ViewResource) noexcept(false)
+    inline View<VideoProcessorInputViewType>::View(ImmediateContext* pDevice, const TDesc12 &Desc, Resource &ViewResource) noexcept(false)
         : ViewBase(pDevice,
             &ViewResource,
             CViewSubresourceSubset(Desc,
@@ -257,7 +257,7 @@ namespace D3D12TranslationLayer
 
     //----------------------------------------------------------------------------------------------------------------------------------
     template<>
-    inline View<VideoProcessorOutputViewType>::View(ImmediateContext* pDevice, const typename TDesc12 &Desc, Resource &ViewResource) noexcept(false)
+    inline View<VideoProcessorOutputViewType>::View(ImmediateContext* pDevice, const TDesc12 &Desc, Resource &ViewResource) noexcept(false)
         : ViewBase(pDevice,
             &ViewResource,
             CViewSubresourceSubset(Desc,


### PR DESCRIPTION
Clang requires typename to appear only before a qualified dependent name (a name containing :: that depends on a template parameter). When typename is used before an unqualified name — such as a typedef alias or a plain template parameter — Clang warns it with:

`warning: expected a qualified name after 'typename'`

MSVC silently accepts redundant typename before unqualified names in all modes, including /permissive- — it has no diagnostic for this pattern. Clang enforces the C++ grammar rule that typename must precede a qualified name (containing :: ), and emits a warning when it doesn't.

**Changes**

1. include/Allocator.h: Removed 2 unnecessary typename on line 110
2. include/View.hpp: Removed typename on lines 120, 123
3. include/View.inl: Removed typename on lines 191, 220, 240, 260

**Validation**

1. Verified the fix resolves all 11 expected a qualified name after 'typename' warnings across multiple OS repo build targets that include these headers via D3D12TranslationLayerIncludes.h.
2. No other instances of this pattern exist in the D3D12TranslationLayer repo.