### PR TITLE
Fix -Winvalid-token-paste Clang warnings

### DIFF
--- a/include/View.hpp
+++ b/include/View.hpp
@@ -51,7 +51,7 @@ namespace D3D12TranslationLayer
     };
 
 #define DECLARE_VIEW_MAPPER(View, DescType12, TranslationLayerDesc) \
-    template<> struct CViewMapper<##View##Type> \
+    template<> struct CViewMapper<View##Type> \
     { \
     typedef TranslationLayerDesc TTranslationLayerDesc; \
     typedef D3D12_##DescType12 TDesc12; \
@@ -59,7 +59,7 @@ namespace D3D12TranslationLayer
     }
 
 #define DECLARE_VIEW_MAPPER1(View, DescType, TranslationLayerDesc) \
-    template<> struct CViewMapper<##View##Type> \
+    template<> struct CViewMapper<View##Type> \
     { \
     typedef TranslationLayerDesc TTranslationLayerDesc; \
     typedef DescType TDesc12; \


### PR DESCRIPTION
## Summary

Remove a spurious `##` between `<` and the `View` macro argument in the `CViewMapper` template specialization. The macro `<##View##Type>` triggers two token-pastes: a left paste of `<` (punctuator) + the substituted identifier (e.g. `ShaderResourceView`), and a right paste of that identifier + `Type` to form the legitimate `ShaderResourceViewType`.

The left paste produces `<ShaderResourceView`, which is two tokens (`<` and `ShaderResourceView`), not one — that's the standards violation clang correctly rejects under `-Winvalid-token-paste`. The right paste is a real identifier-construction and is preserved.

MSVC's traditional preprocessor silently dropped the broken left paste; removing the stray `##` yields the byte-identical token stream the author intended and is now standards-conforming.

## Errors fixed

| File | Error pattern | Count (baseline) |
|---|---|---|
| `include/View.hpp` | `'<ShaderResourceView'`, `'<RenderTargetView'`, `'<DepthStencilView'`, `'<UnorderedAccessView'`, `'<VideoDecoderOutputView'`, `'<VideoProcessorInputView'`, `'<VideoProcessorOutputView'` | 7 (per build target; 50 across all consumers per the original CSV) |

## Validation

Local build.