### PR TITLE
Filter DECODER_OUTPUT format flag for unsupported decode profiles

### DIFF
--- a/src/ImmediateContext.cpp
+++ b/src/ImmediateContext.cpp
@@ -5144,9 +5144,37 @@ void TRANSLATION_API ImmediateContext::GetMipPacking(Resource* pResource, _Out_ 
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------
+static constexpr bool IsPossibleDecodeOutputFormat(DXGI_FORMAT format) noexcept
+{
+    static_assert(VIDEO_DECODE_PROFILE_TYPE_H264_MVC + 1 == VIDEO_DECODE_PROFILE_TYPE_MAX_VALID,
+        "Update IsPossibleDecodeOutputFormat and bump this static_assert when adding a new "
+        "VIDEO_DECODE_PROFILE_TYPE_*. Verify the new codec's legal output formats are covered.");
+    switch (format)
+    {
+    case DXGI_FORMAT_NV12:        // H264, HEVC Main, VP8, VP9 prof0, VC1, MPEG2, MPEG4PT2, H264_MVC
+    case DXGI_FORMAT_P010:        // HEVC Main10, VP9 prof2
+    case DXGI_FORMAT_P016:        // sometimes reported alongside P010
+    case DXGI_FORMAT_YUY2:        // legacy MPEG2/VC1 sometimes
+    case DXGI_FORMAT_420_OPAQUE:  // D3D12 opaque internal format
+        return true;
+    default:
+        return false;
+    }
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------
 HRESULT TRANSLATION_API ImmediateContext::CheckFormatSupport(_Out_ D3D12_FEATURE_DATA_FORMAT_SUPPORT& formatData)
 {
-    return m_pDevice12->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT, &formatData, sizeof(formatData));
+    HRESULT hr = m_pDevice12->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT, &formatData, sizeof(formatData));
+
+    if (SUCCEEDED(hr) &&
+        (formatData.Support1 & D3D12_FORMAT_SUPPORT1_DECODER_OUTPUT) &&
+        !IsPossibleDecodeOutputFormat(formatData.Format))
+    {
+        formatData.Support1 &= ~D3D12_FORMAT_SUPPORT1_DECODER_OUTPUT;
+    }
+
+    return hr;
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
PR #107 filtered the decode profile enumeration in VideoDevice::Initialize() down to the translation-layer-supported set, but left the per-format support side untouched. A format may still report D3D12_FORMAT_SUPPORT1_DECODER_OUTPUT (which D3D11On12 maps to D3D11_1DDI_FORMAT_SUPPORT_DECODER_OUTPUT) even though every decode profile that outputs in that format has been filtered out.

Concretely: AYUV continues to report DECODER_OUTPUT support but every AYUV-outputting decode profile gets filtered, causing HLK WGF11ResourceAccess_Group 13 - ClearView_1_Samples to fail.

Mask DECODER_OUTPUT inside ImmediateContext::CheckFormatSupport when the queried format is not a possible output of any TL-supported decode profile. Implementation is a constexpr allowlist of the legal output formats produced by codecs in AvailableProfiles[] (NV12, P010, P016, YUY2, 420_OPAQUE).

This shape:
- Is a one-liner per call -- no state to consult, no lifetime concerns.
- Works correctly when CheckFormatSupport is called before any VideoDevice has been created (no back-pointer to be null).
- Hot-path-friendly: short-circuits on (Support1 & DECODER_OUTPUT) before doing the format compare; non-DECODER_OUTPUT calls pay zero.
- Lifts the masking into the translation layer so D3D11On12, D3D9On12, and any future consumer inherit the fix without duplicating filter knowledge.

A static_assert ties IsPossibleDecodeOutputFormat to VIDEO_DECODE_PROFILE_TYPE_MAX_VALID so adding a new profile type to AvailableProfiles[] trips a build break, forcing the author to re-evaluate the allowlist.